### PR TITLE
Implement some of the methods inherited from aws.model.KeyPair.

### DIFF
--- a/src/main/scala/awscala/ec2/Requests.scala
+++ b/src/main/scala/awscala/ec2/Requests.scala
@@ -13,7 +13,11 @@ object KeyPair {
   def apply(k: aws.model.KeyPair): KeyPair = KeyPair(k.getKeyName, k.getKeyFingerprint, Option(k.getKeyMaterial))
   def apply(k: aws.model.KeyPairInfo): KeyPair = KeyPair(k.getKeyName, k.getKeyFingerprint, None)
 }
-case class KeyPair(name: String, fingerprint: String, material: Option[String]) extends aws.model.KeyPair
+case class KeyPair(name: String, fingerprint: String, material: Option[String]) extends aws.model.KeyPair {
+  override def getKeyName = name
+  override def getKeyFingerprint = fingerprint
+  override def getKeyMaterial = material.orNull
+}
 
 case class SecurityGroup(
   groupId: String,

--- a/src/test/scala/awscala/KeyPairSpec.scala
+++ b/src/test/scala/awscala/KeyPairSpec.scala
@@ -1,0 +1,41 @@
+package awscala
+
+import awscala._, ec2._
+
+import org.slf4j._
+import org.scalatest._
+import org.scalatest.matchers._
+
+import java.io._
+
+class KeyPairSpec extends FlatSpec with ShouldMatchers {
+
+  behavior of "KeyPair"
+
+  val log = LoggerFactory.getLogger(this.getClass)
+
+  it should "properly implement the inherited Java methods" in {
+    implicit val ec2 = EC2.at(Region.Tokyo)
+
+    val keyPairName = s"awscala-unit-test-keypair-${System.currentTimeMillis}"
+    val keyPair = ec2.createKeyPair(keyPairName)
+
+    try {
+      keyPair.name should be(keyPairName)
+      keyPair.fingerprint.size should be > (0)
+      // Newly created key pair has material (i.e. private key)
+      keyPair.material should be('defined)
+      keyPair.material.get.size should be > (0)
+
+      keyPair.getKeyName should equal(keyPair.name)
+      keyPair.getKeyFingerprint should equal(keyPair.fingerprint)
+      keyPair.getKeyMaterial should equal(keyPair.material.get)
+
+      // Key pair without private key info defined
+      KeyPair("my-key", "fingerprint", None).getKeyMaterial should be(null)
+
+    } finally {
+      ec2.deleteKeyPair(keyPairName)
+    }
+  }
+}


### PR DESCRIPTION
It's easy to accidentally call these methods and end up dealing with
nulls.

Actually, maybe KeyPair doesn't need to extend aws.model.KeyPair anyway?
