### PR TITLE
fix dynamoDB.updateTableProvisionedThroughput

### DIFF
--- a/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
+++ b/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
@@ -99,7 +99,7 @@ trait DynamoDB extends aws.AmazonDynamoDB {
 
   def updateTableProvisionedThroughput(table: Table, provisionedThroughput: ProvisionedThroughput): TableMeta = {
     TableMeta(updateTable(
-      new aws.model.UpdateTableRequest().withProvisionedThroughput(provisionedThroughput)).getTableDescription)
+      new aws.model.UpdateTableRequest(table.name, provisionedThroughput)).getTableDescription)
   }
 
   def delete(table: Table): Unit = deleteTable(table)


### PR DESCRIPTION
table name was ignored in the original code

fixed it.
