### PR TITLE
Upload files as Array[Byte]  to S3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,6 @@ derby.log
 db
 
 .lib
-sbt
+sbt-launch.jar
 
 logs

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,7 @@ object AwscalaProject extends Build {
   lazy val mainSettings: Seq[Project.Setting[_]] = Defaults.defaultSettings ++ Seq(
     organization := "com.github.seratch",
     name := "awscala",
-    version := "0.1.1",
+    version := "0.1.2",
     scalaVersion := "2.10.3",
     crossScalaVersions := Seq("2.10.0"),
     publishTo <<= version { (v: String) => 

--- a/sbt
+++ b/sbt
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+root=$(
+  cd $(dirname $(readlink $0 || echo $0))/..
+  /bin/pwd
+)
+
+sbtjar=sbt-launch.jar
+
+if [ ! -f $sbtjar ]; then
+  echo 'downloading '$sbtjar 1>&2
+  curl -O http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.1/$sbtjar
+fi
+
+test -f $sbtjar || exit 1
+sbtjar_md5=$(openssl md5 < $sbtjar|cut -f2 -d'='|awk '{print $1}')
+if [ "${sbtjar_md5}" != 79e367c11fc2294f865c6ecc47b8886c ]; then
+  echo 'bad sbtjar!' 1>&2
+  exit 1
+fi
+
+
+test -f ~/.sbtconfig && . ~/.sbtconfig
+
+java -ea                          \
+  $SBT_OPTS                       \
+  $JAVA_OPTS                      \
+  -Djava.net.preferIPv4Stack=true \
+  -XX:+AggressiveOpts             \
+  -XX:+UseParNewGC                \
+  -XX:+UseConcMarkSweepGC         \
+  -XX:+CMSParallelRemarkEnabled   \
+  -XX:+CMSClassUnloadingEnabled   \
+  -XX:MaxPermSize=1024m           \
+  -XX:SurvivorRatio=128           \
+  -XX:MaxTenuringThreshold=0      \
+  -XX:ReservedCodeCacheSize=128m  \
+  -Xss8M                          \
+  -Xms512M                        \
+  -Xmx1G                          \
+  -server                         \
+  -jar $sbtjar "$@"

--- a/src/main/scala/awscala/s3/Bucket.scala
+++ b/src/main/scala/awscala/s3/Bucket.scala
@@ -46,6 +46,10 @@ case class Bucket(name: String) extends aws.model.Bucket(name) {
   def putObjectAsPublicRead(key: String, file: File)(implicit s3: S3) = s3.putObjectAsPublicRead(this, key, file)
   def putObjectAsPublicReadWrite(key: String, file: File)(implicit s3: S3) = s3.putObjectAsPublicReadWrite(this, key, file)
 
+  // put object from byte array
+  def putObject(key: String, bytes: Array[Byte], metadata: aws.model.ObjectMetadata)(implicit s3: S3) = s3.putObject(this, key, bytes, metadata)
+  def putObjectAsPublicRead(key: String, bytes: Array[Byte], metadata: aws.model.ObjectMetadata)(implicit s3: S3) = s3.putObjectAsPublicRead(this, key, bytes, metadata)
+
   def delete(obj: S3Object)(implicit s3: S3) = s3.deleteObject(obj)
   def deleteObject(obj: S3Object)(implicit s3: S3) = s3.deleteObject(obj)
 

--- a/src/main/scala/awscala/s3/S3.scala
+++ b/src/main/scala/awscala/s3/S3.scala
@@ -3,7 +3,7 @@ package awscala.s3
 import awscala._
 import scala.collection.JavaConverters._
 import com.amazonaws.services.{ s3 => aws }
-import java.io.File
+import java.io.{ File, ByteArrayInputStream }
 
 object S3 {
 
@@ -111,6 +111,24 @@ trait S3 extends aws.AmazonS3 {
   def putObjectAsPublicReadWrite(bucket: Bucket, key: String, file: File): PutObjectResult = {
     PutObjectResult(bucket, key, putObject(
       new aws.model.PutObjectRequest(bucket.name, key, file).withCannedAcl(aws.model.CannedAccessControlList.PublicReadWrite)))
+  }
+
+  // putting a byte array
+  def put(bucket: Bucket, key: String, bytes: Array[Byte], metadata: aws.model.ObjectMetadata): PutObjectResult = putObject(bucket, key, bytes, metadata)
+  def putAsPublicRead(bucket: Bucket, key: String, bytes: Array[Byte], metadata: aws.model.ObjectMetadata): PutObjectResult = putObjectAsPublicRead(bucket, key, bytes, metadata)
+
+  def putObject(bucket: Bucket, key: String, bytes: Array[Byte], metadata: aws.model.ObjectMetadata): PutObjectResult =
+    PutObjectResult(bucket, key, putObject(
+      new aws.model.PutObjectRequest(bucket.name, key, new ByteArrayInputStream(bytes), metadata)
+    ))
+
+  def putObjectAsPublicRead(bucket: Bucket, key: String, bytes: Array[Byte], metadata: aws.model.ObjectMetadata): PutObjectResult = {
+    PutObjectResult(bucket, key, putObject(
+      new aws.model.PutObjectRequest(bucket.name, key,
+        new ByteArrayInputStream(bytes),
+        metadata
+      ).withCannedAcl(aws.model.CannedAccessControlList.PublicRead))
+    )
   }
 
   // copy


### PR DESCRIPTION
While using this library in proxy that accepts file uploads and saves the files to S3.
Or when a file has to be read from a URL and copied to S3.

Creating a file onto disk and then uploading to S3 adds un-necessary I/O.

When uploading small files, the byte array from HttpMessage can be directly uploaded to S3.

Note: This will not support streaming upload & simultaneous multipart upload to S3.
