### PR TITLE
Small bug corrected, DynamoDBv2 adapter now stores Doubles and Floats as well.

### DIFF
--- a/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
+++ b/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
@@ -11,14 +11,12 @@ object AttributeValue {
     v match {
       case null => null
       case s: String => value.withS(s)
-      case n: Integer => value.withN(n.toString)
-      case n: Long => value.withN(n.toString)
+      case n: java.lang.Number => value.withN(n.toString)
       case n: BigDecimal => value.withN(n.toString)
       case b: ByteBuffer => value.withB(b)
       case xs: Seq[_] => xs.headOption match {
         case Some(s: String) => value.withSS(xs.map(_.asInstanceOf[String]).asJava)
-        case Some(n: Integer) => value.withSS(xs.map(_.toString).asJava)
-        case Some(n: Long) => value.withSS(xs.map(_.toString).asJava)
+        case Some(n: java.lang.Number) => value.withSS(xs.map(_.toString).asJava)
         case Some(n: BigDecimal) => value.withSS(xs.map(_.toString).asJava)
         case Some(s: ByteBuffer) => value.withBS(xs.map(_.asInstanceOf[ByteBuffer]).asJava)
         case Some(v) => value.withSS(xs.map(_.toString).asJava)


### PR DESCRIPTION
Values such as Double, Float, Short and others numbers weren't caught by prior match/case statement.
