### PR TITLE
Get default S3 credentials from DefaultAWSCredentialsProviderChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Tests requires aws credentials with Administrator permissions:
 
 ```
 export AWS_ACCESS_KEY_ID=xxx
-export AWS_SECRET_ACCESS_KEY=yyy
+export AWS_SECRET_KEY=yyy
 ```
 
 The DynamoDB tests also require a locally running instance of DynamoDB.

--- a/src/main/scala/awscala/Credentials.scala
+++ b/src/main/scala/awscala/Credentials.scala
@@ -1,23 +1,5 @@
 package awscala
 
-object Credentials {
-
-  val AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
-  val AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
-
-  def defaultEnv: Credentials = {
-    new Credentials(
-      accessKeyId = Option(System.getenv(AWS_ACCESS_KEY_ID)).getOrElse {
-        throw new IllegalStateException(s"'${AWS_ACCESS_KEY_ID}' env value was not found!")
-      },
-      secretAccessKey = Option(System.getenv(AWS_SECRET_ACCESS_KEY)).getOrElse {
-        throw new IllegalStateException(s"'${AWS_SECRET_ACCESS_KEY}' env value was not found!")
-      }
-    )
-  }
-
-}
-
 case class Credentials(accessKeyId: String, secretAccessKey: String) extends com.amazonaws.auth.AWSCredentials {
 
   override def getAWSAccessKeyId: String = accessKeyId

--- a/src/main/scala/awscala/CredentialsLoader.scala
+++ b/src/main/scala/awscala/CredentialsLoader.scala
@@ -9,14 +9,8 @@ import com.amazonaws.AmazonClientException
 object CredentialsLoader {
 
   def load(): Credentials = {
-    try Credentials.defaultEnv
-    catch {
-      case e: IllegalStateException =>
-        tryCredentials(new EnvironmentVariableCredentialsProvider)
-          .orElse(tryCredentials(new SystemPropertiesCredentialsProvider))
-          .orElse(tryCredentials(new InstanceProfileCredentialsProvider))
-          .getOrElse { throw new IllegalStateException(s"Failed to load AWS credentials! Make sure about environment or configuration.") }
-    }
+    tryCredentials(new DefaultAWSCredentialsProviderChain)
+      .getOrElse { throw new IllegalStateException(s"Failed to load AWS credentials! Make sure about environment or configuration.") }
   }
 
   private[this] def asScala(c: AWSCredentials): Credentials = Credentials(c.getAWSAccessKeyId, c.getAWSSecretKey)


### PR DESCRIPTION
As mentioned in the commit message, this fixes seratch/AWScala#11

Very simple - it just uses the DefaultAWSCredentialsProviderChain when calling awscala.s3.S3()

The original usage of specifying credentials with environment variables still works fine, just need a slightly different environment variable name for the secret to match Amazon conventions.
