### PR TITLE
DynamoDB Global Secondary Index support

### DIFF
--- a/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
+++ b/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
@@ -97,8 +97,12 @@ trait DynamoDB extends aws.AmazonDynamoDB {
           ProvisionedThroughput(readCapacityUnits = 10, writeCapacityUnits = 10)
         }
       )
+
     if (!table.localSecondaryIndexes.isEmpty) {
       req.setLocalSecondaryIndexes(table.localSecondaryIndexes.map(_.asInstanceOf[aws.model.LocalSecondaryIndex]).asJava)
+    }
+    if (!table.globalSecondaryIndexes.isEmpty) {
+      req.setGlobalSecondaryIndexes(table.globalSecondaryIndexes.map(_.asInstanceOf[aws.model.GlobalSecondaryIndex]).asJava)
     }
 
     TableMeta(createTable(req).getTableDescription)
@@ -262,7 +266,7 @@ trait DynamoDB extends aws.AmazonDynamoDB {
   }
 
   def queryWithIndex(table: Table,
-    index: LocalSecondaryIndex,
+    index: SecondaryIndex,
     keyConditions: Seq[(String, aws.model.Condition)],
     select: Select = aws.model.Select.ALL_ATTRIBUTES,
     attributesToGet: Seq[String] = Nil,

--- a/src/main/scala/awscala/dynamodbv2/GlobalSecondaryIndex.scala
+++ b/src/main/scala/awscala/dynamodbv2/GlobalSecondaryIndex.scala
@@ -1,0 +1,26 @@
+package awscala.dynamodbv2
+
+import scala.collection.JavaConverters._
+import com.amazonaws.services.{ dynamodbv2 => aws }
+
+object GlobalSecondaryIndex {
+
+  def apply(v: aws.model.GlobalSecondaryIndexDescription): GlobalSecondaryIndex = new GlobalSecondaryIndex(
+    name = v.getIndexName,
+    keySchema = v.getKeySchema.asScala.map(k => KeySchema(k)),
+    projection = Projection(v.getProjection),
+    provisionedThroughput = ProvisionedThroughput(v.getProvisionedThroughput.getReadCapacityUnits, v.getProvisionedThroughput.getWriteCapacityUnits)
+  )
+
+}
+case class GlobalSecondaryIndex(
+                                name: String,
+                                keySchema: Seq[KeySchema],
+                                projection: Projection,
+                                provisionedThroughput: ProvisionedThroughput) extends aws.model.GlobalSecondaryIndex with SecondaryIndex {
+
+  setIndexName(name)
+  setKeySchema(keySchema.map(_.asInstanceOf[aws.model.KeySchemaElement]).asJava)
+  setProjection(projection)
+  setProvisionedThroughput(provisionedThroughput)
+}

--- a/src/main/scala/awscala/dynamodbv2/LocalSecondaryIndex.scala
+++ b/src/main/scala/awscala/dynamodbv2/LocalSecondaryIndex.scala
@@ -14,7 +14,7 @@ object LocalSecondaryIndex {
 case class LocalSecondaryIndex(
     name: String,
     keySchema: Seq[KeySchema],
-    projection: Projection) extends aws.model.LocalSecondaryIndex {
+    projection: Projection) extends aws.model.LocalSecondaryIndex with SecondaryIndex {
 
   setIndexName(name)
   setKeySchema(keySchema.map(_.asInstanceOf[aws.model.KeySchemaElement]).asJava)

--- a/src/main/scala/awscala/dynamodbv2/SecondaryIndex.scala
+++ b/src/main/scala/awscala/dynamodbv2/SecondaryIndex.scala
@@ -1,0 +1,7 @@
+package awscala.dynamodbv2
+
+trait SecondaryIndex {
+
+  val name: String
+
+}

--- a/src/main/scala/awscala/dynamodbv2/Table.scala
+++ b/src/main/scala/awscala/dynamodbv2/Table.scala
@@ -8,6 +8,7 @@ case class Table(
     rangePK: Option[String] = None,
     attributes: Seq[AttributeDefinition] = Nil,
     localSecondaryIndexes: Seq[LocalSecondaryIndex] = Nil,
+    globalSecondaryIndexes: Seq[GlobalSecondaryIndex] = Nil,
     provisionedThroughput: Option[ProvisionedThroughput] = None) {
 
   // ------------------------------------------
@@ -52,7 +53,7 @@ case class Table(
   }
 
   def queryWithIndex(
-    index: LocalSecondaryIndex,
+    index: SecondaryIndex,
     keyConditions: Seq[(String, aws.model.Condition)],
     select: Select = aws.model.Select.ALL_ATTRIBUTES,
     attributesToGet: Seq[String] = Nil,


### PR DESCRIPTION
Hello, I've added global secondary index support for DynamoDB. 
##### Issue Type:

 Feature request
##### Summary:
- Global secondary index support (DynamoDB)
- Use Matcher instead of ShouldMatcher (will be deprecated)

Thank you.
