### PR TITLE
DynamoDB Projection with NonEmptyKeys is used only when the type is INCLUDE.

### DIFF
--- a/src/main/scala/awscala/dynamodbv2/Projection.scala
+++ b/src/main/scala/awscala/dynamodbv2/Projection.scala
@@ -12,6 +12,11 @@ object Projection {
 
 case class Projection(projectionType: ProjectionType, nonKeyAttributes: Seq[String] = Nil) extends aws.model.Projection {
   setProjectionType(projectionType)
-  setNonKeyAttributes(nonKeyAttributes.asJava)
+
+  if (projectionType == ProjectionType.Include) {
+    setNonKeyAttributes(nonKeyAttributes.asJava)
+  } else if (!nonKeyAttributes.isEmpty) {
+    throw new IllegalArgumentException("You shouldn't specify `nonKeyAttributes` when ProjectionType is other than INCLUDE.")
+  }
 }
 

--- a/src/test/scala/awscala/DynamoDBV2Spec.scala
+++ b/src/test/scala/awscala/DynamoDBV2Spec.scala
@@ -129,7 +129,7 @@ class DynamoDBV2Spec extends FlatSpec with Matchers {
     val globalSecondaryIndex = GlobalSecondaryIndex(
       name = "SexIndex",
       keySchema = Seq(KeySchema("Sex", KeyType.Hash), KeySchema("Age", KeyType.Range)),
-      projection = Projection(ProjectionType.Include, Seq("Name")),
+      projection = Projection(ProjectionType.All),
       provisionedThroughput = ProvisionedThroughput(readCapacityUnits = 10, writeCapacityUnits = 10)
     )
     val table = Table(


### PR DESCRIPTION
Hello, I've fixed a small bug about DynamoDB Projection. `NonEmptyKeys` is used only when the ProjectionType is `INCLUDE`, so I've got the following error when I tried to use `ProjectionType.All` like `Projection(ProjectionType.All)`.

```
No attributes should be specified to be projected unless projection type is INCLUDE (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ValidationException; Request ID: 23cc9ff7-82c8-4b07-9d14-e0ac825fc0f8)
```
#### Issue Type:

Bug fix
#### Summary:
- Projection with NonEmptyKeys is used only when the type is INCLUDE.
#### Reference

http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Projection.html

Thank you.
