### PR TITLE
Pass exception instead of None on failed getObject from S3

### DIFF
--- a/src/main/scala/awscala/AWSException.scala
+++ b/src/main/scala/awscala/AWSException.scala
@@ -1,0 +1,9 @@
+package awscala
+
+/**
+ * Thrown if an unrecoverable error occurred during an AWS call.
+ *
+ * Created by salah_hawila on 10/24/14.
+ */
+class AWSException(msg: String, exception: Throwable = null) extends Exception(msg: String, exception: Throwable) {
+}

--- a/src/main/scala/awscala/AWSException.scala
+++ b/src/main/scala/awscala/AWSException.scala
@@ -2,8 +2,6 @@ package awscala
 
 /**
  * Thrown if an unrecoverable error occurred during an AWS call.
- *
- * Created by salah_hawila on 10/24/14.
  */
 class AWSException(msg: String, exception: Throwable = null) extends Exception(msg: String, exception: Throwable) {
 }

--- a/src/main/scala/awscala/s3/S3.scala
+++ b/src/main/scala/awscala/s3/S3.scala
@@ -1,10 +1,12 @@
 package awscala.s3
 
 import awscala._
+import awscala.s3.S3Object
 import scala.collection.JavaConverters._
 import com.amazonaws.services.{ s3 => aws }
 import java.io.{ File, ByteArrayInputStream }
 import scala.annotation.tailrec
+import scala.util.{Failure, Success, Try}
 
 object S3 {
 
@@ -88,16 +90,16 @@ trait S3 extends aws.AmazonS3 {
 
   def get(bucket: Bucket, key: String, versionId: String) = getObject(bucket, key, versionId)
 
-  def getObject(bucket: Bucket, key: String): Option[S3Object] = try {
-    Option(getObject(new aws.model.GetObjectRequest(bucket.name, key))).map(obj => S3Object(bucket, obj))
-  } catch {
-    case e: aws.model.AmazonS3Exception => None
+  def getObject(bucket: Bucket, key: String): Try[S3Object] = {
+    Try(S3Object(bucket, getObject(new aws.model.GetObjectRequest(bucket.name, key)))).recoverWith {
+      case e: aws.model.AmazonS3Exception => Failure(new AWSException("Error getting S3 object " + key, e))
+    }
   }
 
-  def getObject(bucket: Bucket, key: String, versionId: String): Option[S3Object] = try {
-    Option(getObject(new aws.model.GetObjectRequest(bucket.name, key, versionId))).map(obj => S3Object(bucket, obj))
-  } catch {
-    case e: aws.model.AmazonS3Exception => None
+  def getObject(bucket: Bucket, key: String, versionId: String): Try[S3Object] = {
+    Try(S3Object(bucket, getObject(new aws.model.GetObjectRequest(bucket.name, key, versionId)))).recoverWith {
+      case e: aws.model.AmazonS3Exception => Failure(new AWSException("Error getting S3 object " + key, e))
+    }
   }
 
   def metadata(bucket: Bucket, key: String) = getObjectMetadata(bucket.name, key)

--- a/src/main/scala/awscala/s3/S3.scala
+++ b/src/main/scala/awscala/s3/S3.scala
@@ -1,12 +1,11 @@
 package awscala.s3
 
 import awscala._
-import awscala.s3.S3Object
 import scala.collection.JavaConverters._
 import com.amazonaws.services.{ s3 => aws }
 import java.io.{ File, ByteArrayInputStream }
 import scala.annotation.tailrec
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Try}
 
 object S3 {
 
@@ -90,13 +89,25 @@ trait S3 extends aws.AmazonS3 {
 
   def get(bucket: Bucket, key: String, versionId: String) = getObject(bucket, key, versionId)
 
-  def getObject(bucket: Bucket, key: String): Try[S3Object] = {
+  def getObject(bucket: Bucket, key: String): Option[S3Object] = try {
+    Option(getObject(new aws.model.GetObjectRequest(bucket.name, key))).map(obj => S3Object(bucket, obj))
+  } catch {
+    case e: aws.model.AmazonS3Exception => None
+  }
+
+  def getObject(bucket: Bucket, key: String, versionId: String): Option[S3Object] = try {
+    Option(getObject(new aws.model.GetObjectRequest(bucket.name, key, versionId))).map(obj => S3Object(bucket, obj))
+  } catch {
+    case e: aws.model.AmazonS3Exception => None
+  }
+
+  def tryToGetObject(bucket: Bucket, key: String): Try[S3Object] = {
     Try(S3Object(bucket, getObject(new aws.model.GetObjectRequest(bucket.name, key)))).recoverWith {
       case e: aws.model.AmazonS3Exception => Failure(new AWSException("Error getting S3 object " + key, e))
     }
   }
 
-  def getObject(bucket: Bucket, key: String, versionId: String): Try[S3Object] = {
+  def tryToGetObject(bucket: Bucket, key: String, versionId: String): Try[S3Object] = {
     Try(S3Object(bucket, getObject(new aws.model.GetObjectRequest(bucket.name, key, versionId)))).recoverWith {
       case e: aws.model.AmazonS3Exception => Failure(new AWSException("Error getting S3 object " + key, e))
     }

--- a/src/test/scala/awscala/S3Spec.scala
+++ b/src/test/scala/awscala/S3Spec.scala
@@ -5,8 +5,6 @@ import awscala._, s3._
 import org.slf4j._
 import org.scalatest._
 
-import scala.util.Try
-
 class S3Spec extends FlatSpec with Matchers {
 
   behavior of "S3"

--- a/src/test/scala/awscala/S3Spec.scala
+++ b/src/test/scala/awscala/S3Spec.scala
@@ -56,7 +56,7 @@ class S3Spec extends FlatSpec with Matchers {
     bucket.put("S3Spec.scala", new java.io.File("src/test/scala/awscala/S3Spec.scala"))
 
     // get objects
-    val s3obj: Try[S3Object] = bucket.get("S3.scala")
+    val s3obj: Option[S3Object] = bucket.get("S3.scala")
     log.info(s"Object: ${s3obj}")
     val summaries = bucket.objectSummaries
     log.info(s"Object Summaries: ${summaries}")

--- a/src/test/scala/awscala/S3Spec.scala
+++ b/src/test/scala/awscala/S3Spec.scala
@@ -5,6 +5,8 @@ import awscala._, s3._
 import org.slf4j._
 import org.scalatest._
 
+import scala.util.Try
+
 class S3Spec extends FlatSpec with Matchers {
 
   behavior of "S3"
@@ -54,7 +56,7 @@ class S3Spec extends FlatSpec with Matchers {
     bucket.put("S3Spec.scala", new java.io.File("src/test/scala/awscala/S3Spec.scala"))
 
     // get objects
-    val s3obj: Option[S3Object] = bucket.get("S3.scala")
+    val s3obj: Try[S3Object] = bucket.get("S3.scala")
     log.info(s"Object: ${s3obj}")
     val summaries = bucket.objectSummaries
     log.info(s"Object Summaries: ${summaries}")


### PR DESCRIPTION
We would like to have some information about the S3 exception instead of just getting None.