### PR TITLE
Allow ssh user and timeout parameters

### DIFF
--- a/src/main/scala/awscala/ec2/Instance.scala
+++ b/src/main/scala/awscala/ec2/Instance.scala
@@ -17,8 +17,8 @@ class Instance(val underlying: aws.model.Instance) {
   def terminate()(implicit ec2: EC2) = ec2.terminate(this)
   def reboot()(implicit ec2: EC2) = ec2.reboot(this)
 
-  def withKeyPair(keyPairFile: File)(f: InstanceWithKeyPair => Unit): Unit = {
-    f(InstanceWithKeyPair(underlying, keyPairFile))
+  def withKeyPair(keyPairFile: File, user: String = "ec2-user", connectionTimeout: Int = 30000)(f: InstanceWithKeyPair => Unit): Unit = {
+    f(InstanceWithKeyPair(underlying, keyPairFile, user, connectionTimeout))
   }
 
   def createImage(imageName: String)(implicit ec2: EC2) = {

--- a/src/main/scala/awscala/ec2/InstanceWithKeyPair.scala
+++ b/src/main/scala/awscala/ec2/InstanceWithKeyPair.scala
@@ -3,8 +3,11 @@ package awscala.ec2
 import awscala._
 import com.amazonaws.services.{ ec2 => aws }
 
-case class InstanceWithKeyPair(override val underlying: aws.model.Instance, keyPairFile: File)
-    extends Instance(underlying) {
+case class InstanceWithKeyPair(
+    override val underlying: aws.model.Instance,
+    keyPairFile: File,
+    user: String,
+    connectionTimeout: Int) extends Instance(underlying) {
 
   import com.decodified.scalassh._
 
@@ -16,9 +19,9 @@ case class InstanceWithKeyPair(override val underlying: aws.model.Instance, keyP
         Right("dummy_source" -> (
           Seq(
             "login-type = keyfile",
-            "username = ec2-user",
+            s"username = $user",
             s"keyfile = ${keyPairFile.getAbsolutePath}",
-            "command-timeout = 30000",
+            s"command-timeout = $connectionTimeout",
             "fingerprint = any" //TODO: ask if user will trust any host key provided by the server. Currently it's always YES.
           )))
       } else {


### PR DESCRIPTION
Ssh client assumes 'ec2-user'. This requires implementing a custom HostConfigProvider if the user is 'ubuntu', for instance.
