### PR TITLE
Cross scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,3 +6,5 @@ import SonatypeKeys._
 organization := "com.github.seratch"
 profileName := "com.github.seratch"
 
+crossScalaVersions := Seq("2.10.4", "2.11.4")
+


### PR DESCRIPTION
In order to use in an sbt plugin, a library has to be published for Scala 2.10.