### PR TITLE
fix bug in deleteItem of dynamoDB, will throw 400 unmatch key schema whe...

### DIFF
--- a/src/main/scala/awscala/dynamodbv2/Table.scala
+++ b/src/main/scala/awscala/dynamodbv2/Table.scala
@@ -49,7 +49,7 @@ case class Table(
     dynamoDB.deleteItem(this, hashPK)
   }
   def deleteItem(hashPK: Any, rangePK: Any)(implicit dynamoDB: DynamoDB) = {
-    dynamoDB.deleteItem(this, hashPK, Some(rangePK))
+    dynamoDB.deleteItem(this, hashPK, rangePK)
   }
 
   def queryWithIndex(


### PR DESCRIPTION
fix bug in deleteItem of DynamoDB Table, will throw 400 unmatch key schema when delete with Some(rangePK).

com.amazonaws.AmazonServiceException: The provided key element does not match the schema (Service: AmazonDynamoDBv2; Status Code: 400; Error Code: ValidationException; Request ID: ......