### PR TITLE
Use credentials provider instead of raw credentials so we don't get mess...

### DIFF
--- a/src/main/scala/awscala/BasicCredentialsProvider.scala
+++ b/src/main/scala/awscala/BasicCredentialsProvider.scala
@@ -1,0 +1,15 @@
+package awscala
+
+class BasicCredentialsProvider(accessKey: String, secretKey: String) extends CredentialsProvider {
+  private val credentials: Credentials = Credentials(accessKey, secretKey)
+  override def getCredentials: Credentials = credentials
+  override def refresh: Unit = {}
+}
+
+object BasicCredentialsProvider {
+  def apply(accessKey: String, secretKey: String): BasicCredentialsProvider =
+    new BasicCredentialsProvider(accessKey, secretKey)
+
+  def apply(credentials: Credentials): BasicCredentialsProvider =
+    new BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)
+}

--- a/src/main/scala/awscala/CredentialsProvider.scala
+++ b/src/main/scala/awscala/CredentialsProvider.scala
@@ -1,0 +1,6 @@
+package awscala
+
+trait CredentialsProvider extends com.amazonaws.auth.AWSCredentialsProvider {
+  override def getCredentials: Credentials
+  override def refresh: Unit
+}

--- a/src/main/scala/awscala/DefaultCredentialsProvider.scala
+++ b/src/main/scala/awscala/DefaultCredentialsProvider.scala
@@ -1,0 +1,17 @@
+package awscala
+
+class DefaultCredentialsProvider extends CredentialsProvider {
+  private val provider = new com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+  override def getCredentials: Credentials = {
+    provider.getCredentials match {
+      case sc: com.amazonaws.auth.AWSSessionCredentials => Credentials(sc.getAWSAccessKeyId, sc.getAWSSecretKey, sc.getSessionToken)
+      case c => Credentials(c.getAWSAccessKeyId, c.getAWSSecretKey)
+    }
+  }
+  override def refresh: Unit = provider.refresh
+}
+
+object DefaultCredentialsProvider {
+  def apply(): DefaultCredentialsProvider =
+    new DefaultCredentialsProvider
+}

--- a/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
+++ b/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
@@ -7,8 +7,9 @@ import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes
 
 object DynamoDB {
 
-  def apply(credentials: Credentials = CredentialsLoader.load())(implicit region: Region = Region.default()): DynamoDB = new DynamoDBClient(credentials).at(region)
-  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): DynamoDB = apply(Credentials(accessKeyId, secretAccessKey)).at(region)
+  def apply(credentials: Credentials)(implicit region: Region): DynamoDB = new DynamoDBClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
+  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): DynamoDB = new DynamoDBClient(credentialsProvider).at(region)
+  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): DynamoDB = new DynamoDBClient(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
 
   def at(region: Region): DynamoDB = apply()(region)
 
@@ -334,7 +335,7 @@ trait DynamoDB extends aws.AmazonDynamoDB {
  *
  * @param credentials credentials
  */
-class DynamoDBClient(credentials: Credentials = CredentialsLoader.load())
-  extends aws.AmazonDynamoDBClient(credentials)
+class DynamoDBClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+  extends aws.AmazonDynamoDBClient(credentialsProvider)
   with DynamoDB
 

--- a/src/main/scala/awscala/ec2/EC2.scala
+++ b/src/main/scala/awscala/ec2/EC2.scala
@@ -7,8 +7,9 @@ import scala.annotation.tailrec
 
 object EC2 {
 
-  def apply(credentials: Credentials = CredentialsLoader.load())(implicit region: Region = Region.default()): EC2 = new EC2Client(credentials).at(region)
-  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): EC2 = apply(Credentials(accessKeyId, secretAccessKey)).at(region)
+  def apply(credentials: Credentials)(implicit region: Region): EC2 = new EC2Client(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
+  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): EC2 = new EC2Client(credentialsProvider).at(region)
+  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): EC2 = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
 
   def at(region: Region): EC2 = apply()(region)
 }
@@ -160,6 +161,6 @@ trait EC2 extends aws.AmazonEC2Async {
  *
  * @param credentials credentials
  */
-class EC2Client(credentials: Credentials = CredentialsLoader.load())
-  extends aws.AmazonEC2AsyncClient(credentials)
+class EC2Client(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+  extends aws.AmazonEC2AsyncClient(credentialsProvider)
   with EC2

--- a/src/main/scala/awscala/emr/EMR.scala
+++ b/src/main/scala/awscala/emr/EMR.scala
@@ -9,8 +9,9 @@ import com.amazonaws.services.{ elasticmapreduce => aws }
 import aws.model._
 
 object EMR {
-  def apply(credentials: Credentials = CredentialsLoader.load())(implicit region: Region = Region.default()): EMR = new EMRClient(credentials).at(region)
-  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): EMR = apply(Credentials(accessKeyId, secretAccessKey)).at(region)
+  def apply(credentials: Credentials)(implicit region: Region): EMR = new EMRClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
+  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): EMR = new EMRClient(credentialsProvider).at(region)
+  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): EMR = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
   def at(region: Region): EMR = apply()(region)
 }
 
@@ -267,4 +268,4 @@ trait EMR extends aws.AmazonElasticMapReduce {
 
 }
 
-class EMRClient(credentials: Credentials = CredentialsLoader.load()) extends aws.AmazonElasticMapReduceClient(credentials) with EMR
+class EMRClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load()) extends aws.AmazonElasticMapReduceClient(credentialsProvider) with EMR

--- a/src/main/scala/awscala/iam/IAM.scala
+++ b/src/main/scala/awscala/iam/IAM.scala
@@ -5,9 +5,10 @@ import scala.collection.JavaConverters._
 import com.amazonaws.services.{ identitymanagement => aws }
 
 object IAM {
-  def apply(credentials: Credentials = CredentialsLoader.load()): IAM = new IAMClient(credentials)
+  def apply(credentials: Credentials): IAM = new IAMClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey))
+  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load()): IAM = new IAMClient(credentialsProvider)
   def apply(accessKeyId: String, secretAccessKey: String): IAM = {
-    new IAMClient(Credentials(accessKeyId, secretAccessKey))
+    new IAMClient(BasicCredentialsProvider(accessKeyId, secretAccessKey))
   }
 }
 
@@ -327,6 +328,6 @@ trait IAM extends aws.AmazonIdentityManagement {
  *
  * @param credentials credentials
  */
-class IAMClient(credentials: Credentials = CredentialsLoader.load())
-  extends aws.AmazonIdentityManagementClient(credentials)
+class IAMClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+  extends aws.AmazonIdentityManagementClient(credentialsProvider)
   with IAM

--- a/src/main/scala/awscala/redshift/Redshift.scala
+++ b/src/main/scala/awscala/redshift/Redshift.scala
@@ -6,9 +6,11 @@ import com.amazonaws.services.{ redshift => aws }
 
 object Redshift {
 
-  def apply(credentials: Credentials = CredentialsLoader.load())(implicit region: Region = Region.default()): Redshift = new RedshiftClient(credentials).at(region)
+  def apply(credentials: Credentials)(implicit region: Region): Redshift = new RedshiftClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
 
-  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): Redshift = apply(Credentials(accessKeyId, secretAccessKey)).at(region)
+  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): Redshift = new RedshiftClient(credentialsProvider).at(region)
+
+  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): Redshift = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
 
   def at(region: Region): Redshift = apply()(region)
 }
@@ -313,7 +315,7 @@ trait Redshift extends aws.AmazonRedshift {
  *
  * @param credentials credentials
  */
-class RedshiftClient(credentials: Credentials = CredentialsLoader.load())
-  extends aws.AmazonRedshiftClient(credentials)
+class RedshiftClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+  extends aws.AmazonRedshiftClient(credentialsProvider)
   with Redshift
 

--- a/src/main/scala/awscala/s3/S3.scala
+++ b/src/main/scala/awscala/s3/S3.scala
@@ -8,9 +8,11 @@ import scala.annotation.tailrec
 
 object S3 {
 
-  def apply(credentials: Credentials = CredentialsLoader.load())(implicit region: Region = Region.default()): S3 = new S3Client(credentials).at(region)
+  def apply(credentials: Credentials)(implicit region: Region): S3 = new S3Client(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
 
-  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): S3 = apply(Credentials(accessKeyId, secretAccessKey)).at(region)
+  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): S3 = new S3Client(credentialsProvider).at(region)
+
+  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): S3 = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
 
   def at(region: Region): S3 = apply()(region)
 }
@@ -236,8 +238,8 @@ trait S3 extends aws.AmazonS3 {
  *
  * @param credentials credentials
  */
-class S3Client(credentials: Credentials = CredentialsLoader.load())
-    extends aws.AmazonS3Client(credentials)
+class S3Client(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+    extends aws.AmazonS3Client(credentialsProvider)
     with S3 {
 
   override def createBucket(name: String): Bucket = super.createBucket(name)

--- a/src/main/scala/awscala/simpledb/SimpleDB.scala
+++ b/src/main/scala/awscala/simpledb/SimpleDB.scala
@@ -7,8 +7,9 @@ import com.amazonaws.services.simpledb.model.ListDomainsRequest
 
 object SimpleDB {
 
-  def apply(credentials: Credentials = CredentialsLoader.load())(implicit region: Region = Region.default()): SimpleDB = new SimpleDBClient(credentials).at(region)
-  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): SimpleDB = apply(Credentials(accessKeyId, secretAccessKey)).at(region)
+  def apply(credentials: Credentials)(implicit region: Region): SimpleDB = new SimpleDBClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
+  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): SimpleDB = new SimpleDBClient(credentialsProvider).at(region)
+  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): SimpleDB = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
 
   def at(region: Region): SimpleDB = apply()(region)
 }
@@ -120,7 +121,7 @@ trait SimpleDB extends aws.AmazonSimpleDB {
  *
  * @param credentials credentials
  */
-class SimpleDBClient(credentials: Credentials = CredentialsLoader.load())
-  extends aws.AmazonSimpleDBClient(credentials)
+class SimpleDBClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+  extends aws.AmazonSimpleDBClient(credentialsProvider)
   with SimpleDB
 

--- a/src/main/scala/awscala/sqs/SQS.scala
+++ b/src/main/scala/awscala/sqs/SQS.scala
@@ -7,8 +7,9 @@ import com.amazonaws.auth.AWSSessionCredentials
 
 object SQS {
 
-  def apply(credentials: Credentials = CredentialsLoader.load())(implicit region: Region = Region.default()): SQS = new SQSClient(credentials).at(region)
-  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): SQS = apply(Credentials(accessKeyId, secretAccessKey)).at(region)
+  def apply(credentials: Credentials)(implicit region: Region): SQS = new SQSClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
+  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): SQS = new SQSClient(credentialsProvider).at(region)
+  def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): SQS = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
 
   def at(region: Region): SQS = apply()(region)
 }
@@ -134,7 +135,7 @@ class SQSClientWithQueue(sqs: SQS, queue: Queue) {
  *
  * @param credentials credentials
  */
-class SQSClient(credentials: Credentials = CredentialsLoader.load())
-  extends aws.AmazonSQSClient(credentials)
+class SQSClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+  extends aws.AmazonSQSClient(credentialsProvider)
   with SQS
 

--- a/src/main/scala/awscala/sts/STS.scala
+++ b/src/main/scala/awscala/sts/STS.scala
@@ -6,9 +6,10 @@ import com.amazonaws.util.json.JSONObject
 import java.net._
 
 object STS {
-  def apply(credentials: Credentials = CredentialsLoader.load()): STS = new STSClient(credentials)
+  def apply(credentials: Credentials)(implicit region: Region): STS = new STSClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey))
+  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load()): STS = new STSClient(credentialsProvider)
   def apply(accessKeyId: String, secretAccessKey: String): STS = {
-    new STSClient(Credentials(accessKeyId, secretAccessKey))
+    new STSClient(BasicCredentialsProvider(accessKeyId, secretAccessKey))
   }
 }
 
@@ -77,6 +78,6 @@ trait STS extends aws.AWSSecurityTokenService {
  *
  * @param credentials credentials
  */
-class STSClient(credentials: Credentials = CredentialsLoader.load())
-  extends aws.AWSSecurityTokenServiceClient(credentials)
+class STSClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+  extends aws.AWSSecurityTokenServiceClient(credentialsProvider)
   with STS


### PR DESCRIPTION
This completely fixes seratch/AWScala#11, including full support for IAM Roles.

This is a pretty big change, but using the Amazon client constructor that takes an AWSCredentialsProvider is the only way to support IAM roles without having to manually refresh credentials (which would be an even bigger change).

The relevant AWS java documentation is here:

http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-roles.html

Including the following:

> When using this approach, the SDK will retrieve temporary AWS credentials that have the same permissions as those associated with the IAM role associated with the EC2 instance in its instance profile. Although these credentials are temporary and would eventually expire, InstanceProfileCredentialsProvider will periodically refresh them for you so that the obtained credentials continue to allow access to AWS.
>
> **Important**
> The automatic credentials refresh happens only when you use the default client constructor, which creates its own InstanceProfileCredentialsProvider as part of the default provider chain, or when you pass an InstanceProfileCredentialsProvider instance directly to the client constructor. If you use another method to obtain or pass instance profile credentials, you are responsible for checking for and refreshing expired credentials.

Since there are no tests for Credentials to begin with, I didn't really know what would be worth trying to test as much of the integration testing has to happen with real credentials anyway, but please let me know if and what kind of tests you think would be needed here.