### PR TITLE
add function ls for S3

### DIFF
--- a/src/main/scala/awscala/s3/Bucket.scala
+++ b/src/main/scala/awscala/s3/Bucket.scala
@@ -51,6 +51,9 @@ case class Bucket(name: String) extends aws.model.Bucket(name) {
   def putObjectAsPublicRead(key: String, file: File)(implicit s3: S3) = s3.putObjectAsPublicRead(this, key, file)
   def putObjectAsPublicReadWrite(key: String, file: File)(implicit s3: S3) = s3.putObjectAsPublicReadWrite(this, key, file)
 
+  // ls
+  def ls(prefix: String)(implicit s3: S3) = s3.ls(this, prefix)
+
   // put object from byte array
   def putObject(key: String, bytes: Array[Byte], metadata: aws.model.ObjectMetadata)(implicit s3: S3) = s3.putObject(this, key, bytes, metadata)
   def putObjectAsPublicRead(key: String, bytes: Array[Byte], metadata: aws.model.ObjectMetadata)(implicit s3: S3) = s3.putObjectAsPublicRead(this, key, bytes, metadata)


### PR DESCRIPTION
Enable S3 to list the sub-directories and objects under one directory. Use `"/"` as delimiter.
This is more efficient and convenient than listing all the keys under a prefix and finding the directories in a single level.

Here I use [ListObjectsRequest](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/ListObjectsRequest.html) to implement this feature.

Below is an example to list sub-directories and objects' names under `foo/`:
```scala
s3.ls(bucket, "foo/").foreach {
  case Left(dir) => println("dir: " + dir)
  case Right(obj) => println("obj: " + obj.getKey)
}
```