### PR TITLE
Fix #63

### DIFF
--- a/src/main/scala/awscala/Region0.scala
+++ b/src/main/scala/awscala/Region0.scala
@@ -1,6 +1,6 @@
 package awscala
 
-object Region {
+object Region0 {
 
   import com.amazonaws.{ regions => awsregions }
 

--- a/src/main/scala/awscala/ec2/InstanceType0.scala
+++ b/src/main/scala/awscala/ec2/InstanceType0.scala
@@ -2,7 +2,7 @@ package awscala.ec2
 
 import com.amazonaws.services.{ ec2 => aws }
 
-object InstanceType {
+object InstanceType0 {
   val T2_Small = aws.model.InstanceType.T2Small
   val T2_Micro = aws.model.InstanceType.T2Micro
   val T2_Medium = aws.model.InstanceType.T2Medium

--- a/src/main/scala/awscala/ec2/package.scala
+++ b/src/main/scala/awscala/ec2/package.scala
@@ -3,7 +3,8 @@ package awscala
 import scala.language.implicitConversions
 
 package object ec2 {
-
+  // Workaround for https://issues.scala-lang.org/browse/SI-7139
+  val InstanceType = InstanceType0
   type InstanceType = com.amazonaws.services.ec2.model.InstanceType
 
   implicit def fromInstanceToSSHEnabledInstance(instance: Instance): SSHEnabledInstance = SSHEnabledInstance(instance)

--- a/src/main/scala/awscala/package.scala
+++ b/src/main/scala/awscala/package.scala
@@ -1,5 +1,6 @@
 package object awscala {
-
+  // Workaround for https://issues.scala-lang.org/browse/SI-7139
+  val Region: Region0.type = Region0
   type Region = com.amazonaws.regions.Region
   type DateTime = org.joda.time.DateTime
   type ByteBuffer = java.nio.ByteBuffer


### PR DESCRIPTION
This implements the workaround described by @retronym in https://issues.scala-lang.org/browse/SI-7139. Since the compiler doesn't like the type alias and object to live in separate files, we rename the object and put a forwarding `val` in the same file as the type alias.