### PR TITLE
Upgrade to sbt-sonatype-0.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,4 @@
 scalariformSettings
-sonatypeSettings
 
-import SonatypeKeys._
 organization := "com.github.seratch"
-profileName := "com.github.seratch"
+sonatypeProfileName := "com.github.seratch"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,11 +13,6 @@ object AwscalaProject extends Build {
     version := "0.5.2",
     scalaVersion := "2.11.6",
     crossScalaVersions := Seq("2.11.6", "2.10.5"),
-    publishTo <<= version { (v: String) =>
-      val nexus = "https://oss.sonatype.org/"
-      if (v.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "content/repositories/snapshots")
-      else Some("releases" at nexus + "service/local/staging/deploy/maven2")
-    },
     publishMavenStyle := true,
     resolvers += "spray repo" at "http://repo.spray.io",
     libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform"      % "1.3.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"          % "0.1.8")
-addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype"         % "0.2.2")
+addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype"         % "0.5.0")
 addSbtPlugin("com.jsuereth"     % "sbt-pgp"              % "1.0.0")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")


### PR DESCRIPTION
Upgrade to sbt-sonatype-0.5.0, which makes simpler the sbt settings. Major changes include: 
 - sbt-sonatype is now an auto-plugin: `sonatypeSettings` (e.g., `publishTo`, `sonatypeRelease` commands, etc.) are automatically loaded.
 - `profileName` is prefixed with `sonatype`