### PR TITLE
Add support for document maps

### DIFF
--- a/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
+++ b/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
@@ -3,8 +3,16 @@ package awscala.dynamodbv2
 import awscala._
 import scala.collection.JavaConverters._
 import com.amazonaws.services.{ dynamodbv2 => aws }
+import java.util.{ Map => JMap }
 
 object AttributeValue {
+
+  def recurseMapValue(valueMap: Map[String, Any]): Map[String, aws.model.AttributeValue] = valueMap.map {
+    case (key, vl: Map[String, Any]) =>
+      key -> new aws.model.AttributeValue().withM(recurseMapValue(vl).asJava)
+    case (key: String, vl: Object) =>
+      key -> new aws.model.AttributeValue(vl.toString)
+  }
 
   def toJavaValue(v: Any): aws.model.AttributeValue = {
     val value = new aws.model.AttributeValue
@@ -20,6 +28,7 @@ object AttributeValue {
         case Some(v) => value.withSS(xs.map(_.toString).asJava)
         case _ => null
       }
+      case m: Map[String, Any] => value.withM(recurseMapValue(m).asJava)
       case _ => null
     }
   }
@@ -28,6 +37,7 @@ object AttributeValue {
     s = Option(v.getS),
     n = Option(v.getN),
     b = Option(v.getB),
+    m = Option(v.getM),
     ss = Option(v.getSS).map(_.asScala).getOrElse(Nil),
     ns = Option(v.getNS).map(_.asScala).getOrElse(Nil),
     bs = Option(v.getBS).map(_.asScala).getOrElse(Nil)
@@ -38,6 +48,7 @@ case class AttributeValue(
     s: Option[String] = None,
     n: Option[String] = None,
     b: Option[ByteBuffer] = None,
+    m: Option[JMap[String, aws.model.AttributeValue]] = None,
     ss: Seq[String] = Nil,
     ns: Seq[String] = Nil,
     bs: Seq[ByteBuffer] = Nil) extends aws.model.AttributeValue {
@@ -45,6 +56,7 @@ case class AttributeValue(
   setS(s.orNull[String])
   setN(n.orNull[String])
   setB(b.orNull[ByteBuffer])
+  setM(m.orNull[JMap[String, aws.model.AttributeValue]])
   setSS(ss.asJava)
   setNS(ns.asJava)
   setBS(bs.asJava)

--- a/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
+++ b/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
@@ -7,8 +7,8 @@ import java.util.{ Map => JMap }
 
 object AttributeValue {
 
-  def recurseMapValue(valueMap: Map[String, Any]): Map[String, aws.model.AttributeValue] = valueMap.map {
-    case (key, xs:Seq[_]) =>
+  private def recurseMapValue(valueMap: Map[String, Any]): Map[String, aws.model.AttributeValue] = valueMap.map {
+    case (key, xs: Seq[_]) =>
       key -> toJavaValue(xs)
     case (key, vl: Map[String, Any]) =>
       key -> new aws.model.AttributeValue().withM(recurseMapValue(vl).asJava)

--- a/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
+++ b/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
@@ -8,10 +8,12 @@ import java.util.{ Map => JMap }
 object AttributeValue {
 
   def recurseMapValue(valueMap: Map[String, Any]): Map[String, aws.model.AttributeValue] = valueMap.map {
+    case (key, xs:Seq[_]) =>
+      key -> toJavaValue(xs)
     case (key, vl: Map[String, Any]) =>
       key -> new aws.model.AttributeValue().withM(recurseMapValue(vl).asJava)
     case (key: String, vl: Object) =>
-      key -> new aws.model.AttributeValue(vl.toString)
+      key -> toJavaValue(vl)
   }
 
   def toJavaValue(v: Any): aws.model.AttributeValue = {

--- a/src/test/scala/awscala/DynamoDBV2Spec.scala
+++ b/src/test/scala/awscala/DynamoDBV2Spec.scala
@@ -158,8 +158,8 @@ class DynamoDBV2Spec extends FlatSpec with Matchers {
     members.put(1, "Japan", "Name" -> Map("foo" -> Map("bar" -> "brack")), "Age" -> 23, "Company" -> "Google")
     members.get(1, "Japan").get.attributes.find(_.name == "Name").get.value.m.get.get("foo").getM().get("bar").getS() should equal("brack")
 
-    members.put(2, "Micronesia", "Name" -> Map("aliases" -> List("foo","bar","other")), "Age"->26, "Company"->"Spotify")
-    members.get(2, "Micronesia").get.attributes.find(_.name == "Name").get.value.m.get.get("aliases").getSS() should contain allOf("foo","bar","other")
+    members.put(2, "Micronesia", "Name" -> Map("aliases" -> List("foo", "bar", "other")), "Age" -> 26, "Company" -> "Spotify")
+    members.get(2, "Micronesia").get.attributes.find(_.name == "Name").get.value.m.get.get("aliases").getSS() should contain allOf ("foo", "bar", "other")
   }
 
   it should "provide cool APIs to use global secondary index" in {

--- a/src/test/scala/awscala/DynamoDBV2Spec.scala
+++ b/src/test/scala/awscala/DynamoDBV2Spec.scala
@@ -156,7 +156,10 @@ class DynamoDBV2Spec extends FlatSpec with Matchers {
     val members: Table = dynamoDB.table(tableName).get
 
     members.put(1, "Japan", "Name" -> Map("foo" -> Map("bar" -> "brack")), "Age" -> 23, "Company" -> "Google")
-    members.get(1, "Japan").get.attributes.find(_.name == "Name").get.value.m.get.get("foo").getM().get("bar").getS() should equal ("brack")
+    members.get(1, "Japan").get.attributes.find(_.name == "Name").get.value.m.get.get("foo").getM().get("bar").getS() should equal("brack")
+
+    members.put(2, "Micronesia", "Name" -> Map("aliases" -> List("foo","bar","other")), "Age"->26, "Company"->"Spotify")
+    members.get(2, "Micronesia").get.attributes.find(_.name == "Name").get.value.m.get.get("aliases").getSS() should contain allOf("foo","bar","other")
   }
 
   it should "provide cool APIs to use global secondary index" in {

--- a/src/test/scala/awscala/DynamoDBV2Spec.scala
+++ b/src/test/scala/awscala/DynamoDBV2Spec.scala
@@ -122,6 +122,43 @@ class DynamoDBV2Spec extends FlatSpec with Matchers {
     members.destroy()
   }
 
+  it should "convert maps to attribute values implicitly" in {
+    implicit val dynamoDB = DynamoDB.local()
+
+    val tableName = s"Members_${System.currentTimeMillis}"
+    val createdTableMeta: TableMeta = dynamoDB.createTable(
+      name = tableName,
+      hashPK = "Id" -> AttributeType.Number,
+      rangePK = "Country" -> AttributeType.String,
+      otherAttributes = Seq("Company" -> AttributeType.String),
+      indexes = Seq(
+        LocalSecondaryIndex(
+          name = "CompanyIndex",
+          keySchema = Seq(KeySchema("Id", KeyType.Hash), KeySchema("Company", KeyType.Range)),
+          projection = Projection(ProjectionType.Include, Seq("Company"))
+        )
+      )
+    )
+    log.info(s"Created Table: ${createdTableMeta}")
+
+    println(s"Waiting for DynamoDB table activation...")
+    var isTableActivated = false
+    while (!isTableActivated) {
+      dynamoDB.describe(createdTableMeta.table).map { meta =>
+        isTableActivated = meta.status == aws.model.TableStatus.ACTIVE
+      }
+      Thread.sleep(1000L)
+      print(".")
+    }
+    println("")
+    println(s"Created DynamoDB table has been activated.")
+
+    val members: Table = dynamoDB.table(tableName).get
+
+    members.put(1, "Japan", "Name" -> Map("foo" -> Map("bar" -> "brack")), "Age" -> 23, "Company" -> "Google")
+    members.get(1, "Japan").get.attributes.find(_.name == "Name").get.value.m.get.get("foo").getM().get("bar").getS() should equal ("brack")
+  }
+
   it should "provide cool APIs to use global secondary index" in {
     implicit val dynamoDB = DynamoDB.local()
 


### PR DESCRIPTION
I'd be interested in your thoughts on this draft.

It allows passing arbitrarily nested maps to `AttributeValue` to make use of dynamo's [new map/document support](http://aws.amazon.com/blogs/aws/dynamodb-update-json-and-more/).

Right now this is accomplished by coercing any leaf values to string using .toString, but pending review I can generalize it out to other leaf types (keeping the string/number/bytes convention of dynamo)