### PR TITLE
fix the bug that awaitInstances doesn't wait since pending != Pending

### DIFF
--- a/src/main/scala/awscala/ec2/EC2.scala
+++ b/src/main/scala/awscala/ec2/EC2.scala
@@ -56,7 +56,7 @@ trait EC2 extends aws.AmazonEC2Async {
   @tailrec
   final def awaitInstances(awaiting: Seq[Instance], checkInterval: Long = 5000L): Seq[Instance] = {
     val requested = instances(awaiting.map(_.instanceId))
-    if (requested.exists(_.state.getName == aws.model.InstanceStateName.Pending.name())) {
+    if (requested.exists(_.state.getName == "pending")) {
       Thread.sleep(checkInterval)
       awaitInstances(awaiting, checkInterval)
     } else {

--- a/src/main/scala/awscala/ec2/EC2.scala
+++ b/src/main/scala/awscala/ec2/EC2.scala
@@ -56,7 +56,7 @@ trait EC2 extends aws.AmazonEC2Async {
   @tailrec
   final def awaitInstances(awaiting: Seq[Instance], checkInterval: Long = 5000L): Seq[Instance] = {
     val requested = instances(awaiting.map(_.instanceId))
-    if (requested.exists(_.state.getName == "pending")) {
+    if (requested.exists(_.state.getName == aws.model.InstanceStateName.Pending.toString)) {
       Thread.sleep(checkInterval)
       awaitInstances(awaiting, checkInterval)
     } else {


### PR DESCRIPTION
If the instance is in pending state, `_.state.getName` will get value `"pending"`, but the value of `aws.model.InstanceStateName.Pending.name()` is always `"Pending"`, hence `awaitInstances` will never wait for the instances to be ready.