### PR TITLE
Add scan index forward argumnet

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,7 +10,7 @@ object AwscalaProject extends Build {
   lazy val mainSettings = Seq(
     organization := "com.github.seratch",
     name := "awscala",
-    version := "0.5.4",
+    version := "0.5.5-SNAPSHOT",
     scalaVersion := "2.11.7",
     crossScalaVersions := Seq("2.11.7", "2.10.6"),
     publishMavenStyle := true,

--- a/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
+++ b/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
@@ -292,12 +292,14 @@ trait DynamoDB extends aws.AmazonDynamoDB {
     keyConditions: Seq[(String, aws.model.Condition)],
     select: Select = aws.model.Select.ALL_ATTRIBUTES,
     attributesToGet: Seq[String] = Nil,
+    scanIndexForward: Boolean = true,
     consistentRead: Boolean = false): Seq[Item] = try {
 
     val req = new aws.model.QueryRequest()
       .withTableName(table.name)
       .withKeyConditions(keyConditions.toMap.asJava)
       .withSelect(select)
+      .withScanIndexForward(scanIndexForward)
       .withConsistentRead(consistentRead)
     if (!attributesToGet.isEmpty) {
       req.setAttributesToGet(attributesToGet.asJava)

--- a/src/main/scala/awscala/dynamodbv2/Table.scala
+++ b/src/main/scala/awscala/dynamodbv2/Table.scala
@@ -57,6 +57,7 @@ case class Table(
     keyConditions: Seq[(String, aws.model.Condition)],
     select: Select = aws.model.Select.ALL_ATTRIBUTES,
     attributesToGet: Seq[String] = Nil,
+    scanIndexForward: Boolean = true,
     consistentRead: Boolean = false)(implicit dynamoDB: DynamoDB): Seq[Item] = {
     dynamoDB.queryWithIndex(
       table = this,
@@ -64,6 +65,7 @@ case class Table(
       keyConditions = keyConditions,
       select = select,
       attributesToGet = attributesToGet,
+      scanIndexForward = scanIndexForward,
       consistentRead = consistentRead)
   }
 
@@ -71,12 +73,14 @@ case class Table(
     keyConditions: Seq[(String, aws.model.Condition)],
     select: Select = aws.model.Select.ALL_ATTRIBUTES,
     attributesToGet: Seq[String] = Nil,
+    scanIndexForward: Boolean = true,
     consistentRead: Boolean = false)(implicit dynamoDB: DynamoDB): Seq[Item] = {
     dynamoDB.query(
       table = this,
       keyConditions = keyConditions,
       select = select,
       attributesToGet = attributesToGet,
+      scanIndexForward = scanIndexForward,
       consistentRead = consistentRead)
   }
 


### PR DESCRIPTION
Allows reverse sorted results on the primary index. This also adds the method to the table class for both query and queryWithIndex.