### PR TITLE
Add List with Map support to dynamodb v2

### DIFF
--- a/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
+++ b/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
@@ -24,6 +24,7 @@ object AttributeValue {
       case n: java.lang.Number => value.withN(n.toString)
       case b: ByteBuffer => value.withB(b)
       case xs: Seq[_] => xs.headOption match {
+        case Some(m: Map[String, Any]) => value.withL(xs.map(toJavaValue).asJavaCollection)
         case Some(s: String) => value.withSS(xs.map(_.asInstanceOf[String]).asJava)
         case Some(n: java.lang.Number) => value.withSS(xs.map(_.toString).asJava)
         case Some(s: ByteBuffer) => value.withBS(xs.map(_.asInstanceOf[ByteBuffer]).asJava)
@@ -40,6 +41,7 @@ object AttributeValue {
     n = Option(v.getN),
     b = Option(v.getB),
     m = Option(v.getM),
+    l = Option(v.getL).map(_.asScala).getOrElse(Nil),
     ss = Option(v.getSS).map(_.asScala).getOrElse(Nil),
     ns = Option(v.getNS).map(_.asScala).getOrElse(Nil),
     bs = Option(v.getBS).map(_.asScala).getOrElse(Nil)
@@ -51,6 +53,7 @@ case class AttributeValue(
     n: Option[String] = None,
     b: Option[ByteBuffer] = None,
     m: Option[JMap[String, aws.model.AttributeValue]] = None,
+    l: Seq[aws.model.AttributeValue],
     ss: Seq[String] = Nil,
     ns: Seq[String] = Nil,
     bs: Seq[ByteBuffer] = Nil) extends aws.model.AttributeValue {
@@ -59,6 +62,7 @@ case class AttributeValue(
   setN(n.orNull[String])
   setB(b.orNull[ByteBuffer])
   setM(m.orNull[JMap[String, aws.model.AttributeValue]])
+  setL(l.asJavaCollection)
   setSS(ss.asJava)
   setNS(ns.asJava)
   setBS(bs.asJava)

--- a/src/test/scala/awscala/DynamoDBV2Spec.scala
+++ b/src/test/scala/awscala/DynamoDBV2Spec.scala
@@ -162,6 +162,44 @@ class DynamoDBV2Spec extends FlatSpec with Matchers {
     members.get(2, "Micronesia").get.attributes.find(_.name == "Name").get.value.m.get.get("aliases").getSS() should contain allOf ("foo", "bar", "other")
   }
 
+  it should "convert list of maps to attribute values implicitly" in {
+    implicit val dynamoDB = DynamoDB.local()
+
+    val tableName = s"Members_${System.currentTimeMillis}"
+    val createdTableMeta: TableMeta = dynamoDB.createTable(
+      name = tableName,
+      hashPK = "Id" -> AttributeType.Number,
+      rangePK = "Country" -> AttributeType.String,
+      otherAttributes = Seq("Company" -> AttributeType.String),
+      indexes = Seq(
+        LocalSecondaryIndex(
+          name = "CompanyIndex",
+          keySchema = Seq(KeySchema("Id", KeyType.Hash), KeySchema("Company", KeyType.Range)),
+          projection = Projection(ProjectionType.Include, Seq("Company"))
+        )
+      )
+    )
+    log.info(s"Created Table: ${createdTableMeta}")
+
+    println(s"Waiting for DynamoDB table activation...")
+    var isTableActivated = false
+    while (!isTableActivated) {
+      dynamoDB.describe(createdTableMeta.table).map { meta =>
+        isTableActivated = meta.status == aws.model.TableStatus.ACTIVE
+      }
+      Thread.sleep(1000L)
+      print(".")
+    }
+    println("")
+    println(s"Created DynamoDB table has been activated.")
+
+    val members: Table = dynamoDB.table(tableName).get
+
+    members.put(1, "Japan", "Name" -> List(Map("bar" -> "brack")), "Age" -> 23, "Company" -> "Google")
+    members.get(1, "Japan").get.attributes.find(_.name == "Name").get.value.m.get.get(0).getM()
+      .get("bar").getS() should equal("brack")
+  }
+
   it should "provide cool APIs to use global secondary index" in {
     implicit val dynamoDB = DynamoDB.local()
 


### PR DESCRIPTION
This project do not support a map inside a list/array but the DynamoDB does. Today the project supports only string set, number set or binary set.  This PR add the support (list of map) to AWScala lib.

Sample (`parsingErrors` attribute problem):
```json 
{
  "client": "client-name",
  "phase": "Finished",   
  "parsingErrors": [
    {
      "line": 1,
      "column": 2,
      "msg": "there is a problem in XML"
    }
  ],
  "url": "http://testingurl.com/test-client.xml"
}
```

