### PR TITLE
WIP: Support nested lists with maps

### DIFF
--- a/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
+++ b/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
@@ -1,6 +1,7 @@
 package awscala.dynamodbv2
 
 import awscala._
+import com.amazonaws.services.dynamodbv2.model
 import scala.collection.JavaConverters._
 import com.amazonaws.services.{ dynamodbv2 => aws }
 import java.util.{ Map => JMap }
@@ -16,6 +17,17 @@ object AttributeValue {
       key -> toJavaValue(vl)
   }
 
+  private def recurseListValue(l: Seq[_]): Seq[aws.model.AttributeValue] = l.map {
+    case v: AttributeValue =>
+      v
+    case v: Map[String, Any] =>
+      new aws.model.AttributeValue().withM(recurseMapValue(v).asJava)
+    case v: Seq[_] =>
+      new aws.model.AttributeValue().withL(recurseListValue(v).asJavaCollection)
+    case v =>
+      toJavaValue(v)
+  }
+
   def toJavaValue(v: Any): aws.model.AttributeValue = {
     val value = new aws.model.AttributeValue
     v match {
@@ -28,7 +40,8 @@ object AttributeValue {
         case Some(s: String) => value.withSS(xs.map(_.asInstanceOf[String]).asJava)
         case Some(n: java.lang.Number) => value.withSS(xs.map(_.toString).asJava)
         case Some(s: ByteBuffer) => value.withBS(xs.map(_.asInstanceOf[ByteBuffer]).asJava)
-        case Some(v) => value.withSS(xs.map(_.toString).asJava)
+        case Some(av: AttributeValue) => value.withL(recurseListValue(xs).asJavaCollection)
+        case Some(v) => value.withL(recurseListValue(xs).asJavaCollection)
         case _ => null
       }
       case m: Map[String, Any] => value.withM(recurseMapValue(m).asJava)
@@ -36,11 +49,19 @@ object AttributeValue {
     }
   }
 
+  def unpackListValue(av: java.util.List[aws.model.AttributeValue]): List[AttributeValue] = av.asScala.toList.map {
+    case x: aws.model.AttributeValue if x.getL == null =>
+      AttributeValue(x)
+    case x: aws.model.AttributeValue if x.getL != null =>
+      AttributeValue(l = unpackListValue(x.getL))
+  }
+
   def apply(v: aws.model.AttributeValue): AttributeValue = new AttributeValue(
     s = Option(v.getS),
     bl = Option[java.lang.Boolean](v.getBOOL).map(_.booleanValue()),
     n = Option(v.getN),
     b = Option(v.getB),
+    l = Option(v.getL).map(unpackListValue).getOrElse(Nil),
     m = Option(v.getM),
     ss = Option(v.getSS).map(_.asScala).getOrElse(Nil),
     ns = Option(v.getNS).map(_.asScala).getOrElse(Nil),
@@ -53,6 +74,7 @@ case class AttributeValue(
     bl: Option[Boolean] = None,
     n: Option[String] = None,
     b: Option[ByteBuffer] = None,
+    l: Seq[AttributeValue] = Nil,
     m: Option[JMap[String, aws.model.AttributeValue]] = None,
     ss: Seq[String] = Nil,
     ns: Seq[String] = Nil,
@@ -63,6 +85,7 @@ case class AttributeValue(
   bl.foreach(setBOOL(_))
   setN(n.orNull[String])
   setB(b.orNull[ByteBuffer])
+  setL(l.map(_.asInstanceOf[aws.model.AttributeValue]).asJavaCollection)
   setM(m.orNull[JMap[String, aws.model.AttributeValue]])
   setSS(ss.asJava)
   setNS(ns.asJava)


### PR DESCRIPTION
The present implementation [coerces sequences it can't determine the type of to a string set](https://github.com/seratch/AWScala/blob/master/src/main/scala/awscala/dynamodbv2/AttributeValue.scala#L31) and calls `toString` on it's members.  This simple form of improvised serialization can work in most cases, but tends to be an impediment in the case of nested object graphs.

This patch is conceptually similar to #99, but also unpacks the to their AWScala equivalents `aws.dynamodb.model.AttributeValue => AttributeValue` on fetch.  Would appreciate feedback on the approach here as parts feel a bit clumsy.