### PR TITLE
S3 batch deletion fixes

### DIFF
--- a/src/main/scala/awscala/s3/Bucket.scala
+++ b/src/main/scala/awscala/s3/Bucket.scala
@@ -62,6 +62,7 @@ case class Bucket(name: String) extends aws.model.Bucket(name) {
   def delete(key: String)(implicit s3: S3) = s3.deleteObject(name, key)
   def delete(obj: S3Object)(implicit s3: S3) = s3.deleteObject(obj)
   def deleteObject(obj: S3Object)(implicit s3: S3) = s3.deleteObject(obj)
+  def deleteObjects(objs: Seq[S3Object])(implicit s3: S3) = s3.deleteObjects(objs)
 
   // configuration
   def crossOriginConfig()(implicit s3: S3) = s3.crossOriginConfig(this)

--- a/src/main/scala/awscala/s3/S3Object.scala
+++ b/src/main/scala/awscala/s3/S3Object.scala
@@ -15,8 +15,8 @@ object S3Object {
 }
 
 case class S3Object(
-  bucket: Bucket, key: String, content: java.io.InputStream,
-  redirectLocation: String, metadata: aws.model.ObjectMetadata
+  bucket: Bucket, key: String, content: java.io.InputStream = null,
+  redirectLocation: String = null, metadata: aws.model.ObjectMetadata = null
 )
     extends aws.model.S3Object {
 
@@ -42,7 +42,7 @@ case class S3Object(
     s3.generatePresignedUrl(this, expiration)
   }
 
-  def versionId: String = metadata.getVersionId
+  lazy val versionId: String = Option(metadata).map(_.getVersionId).getOrElse(null)
 
   def destroy()(implicit s3: S3): Unit = s3.deleteObject(this)
 }


### PR DESCRIPTION
AWS limits the batch deletion of S3 objects to 1000 objects per
request. The list of S3 objects gets grouped into buckets of up
to 1000 objects, each of the buckets generates is handled within
a separate deletion request.

The creation of S3 objects based on summary streams has been
simplified to support batch deletion patterns:

    val bucket = s3.bucket("...")
    val s3objs = bucket.keys("...").map( os => S3Object(bucket, os.getKey))

    s3.deleteObjects(bucket, s3objs)
    bucket.deleteObjects(s3objs)

Meta-data and content are automatically set to null.