### PR TITLE
WIP Update AWS Java SDK version

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,7 +3,7 @@ import Keys._
 
 object AwscalaProject extends Build {
 
-  lazy val awsJavaSdkVersion = "1.10.77"
+  lazy val awsJavaSdkVersion = "1.11.22"
 
   lazy val root = Project("root", file("."), settings = mainSettings)
 

--- a/src/main/scala/awscala/sts/STS.scala
+++ b/src/main/scala/awscala/sts/STS.scala
@@ -2,7 +2,7 @@ package awscala.sts
 
 import awscala._
 import com.amazonaws.services.{ securitytoken => aws }
-import com.amazonaws.util.json.JSONObject
+import com.amazonaws.util.json.Jackson
 import java.net._
 
 object STS {
@@ -52,7 +52,7 @@ trait STS extends aws.AWSSecurityTokenService {
     val sessionJsonValue = s"""{"sessionId":"${credentials.accessKeyId}","sessionKey":"${credentials.secretAccessKey}","sessionToken":"${credentials.sessionToken}"}\n"""
     val url = SIGNIN_URL + "?Action=getSigninToken&SessionType=json&Session=" + java.net.URLEncoder.encode(sessionJsonValue, "UTF-8")
     val response = scala.io.Source.fromURL(new java.net.URL(url)).getLines.mkString("\n")
-    new JSONObject(response).getString("SigninToken")
+    Jackson.jsonNodeOf(response).get("SigninToken").asText()
   }
 
   def loginUrl(credentials: TemporaryCredentials, consoleUrl: String = "https://console.aws.amazon.com/iam", issuerUrl: String = ""): String = {


### PR DESCRIPTION
This updates the Java SDK dependency to the latest version, since 1.10.x is now in maintenance mode. The PR fixes the compile errors but there are still deprecation warnings to address so this is a WIP.

Some of the deprecation warnings are about providing credentials directly instead of the much more flexible 'credentials providers'. [I raised this related issue earlier](https://github.com/seratch/AWScala/issues/128), it'd probably be worth looking at that at the same time.

I've opened this now to see if there's any appetite for this or any strong feelings about how it should happen. I'm happy to help sort it out.
