### PR TITLE
SQS Message has messageAttributes

### DIFF
--- a/src/main/scala/awscala/sqs/Message.scala
+++ b/src/main/scala/awscala/sqs/Message.scala
@@ -1,5 +1,6 @@
 package awscala.sqs
 
+import com.amazonaws.services.sqs.model.MessageAttributeValue
 import scala.collection.JavaConverters._
 
 object Message {
@@ -9,17 +10,26 @@ object Message {
     id = msg.getMessageId,
     body = msg.getBody,
     receiptHandle = msg.getReceiptHandle,
-    attributes = msg.getAttributes.asScala.toMap
+    attributes = msg.getAttributes.asScala.toMap,
+    messageAttributes = msg.getMessageAttributes.asScala.toMap
   )
 }
 
-case class Message(queue: Queue, id: String, body: String, receiptHandle: String, attributes: Map[String, String])
+case class Message(
+  queue: Queue,
+  id: String,
+  body: String,
+  receiptHandle: String,
+  attributes: Map[String, String],
+  messageAttributes: Map[String, MessageAttributeValue] = Map()
+)
     extends com.amazonaws.services.sqs.model.Message {
 
   setMessageId(id)
   setBody(body)
   setReceiptHandle(receiptHandle)
   setAttributes(attributes.asJava)
+  setMessageAttributes(messageAttributes.asJava)
 
   def destroy()(implicit sqs: SQS): Unit = sqs.deleteMessage(this)
 


### PR DESCRIPTION
Allows user to construct an awscala Message from an aws-sdk-java
Message without loosing the messageAttributes.
(Note messageAttributes and attributes are different).