### PR TITLE
Add default value for AttributeValue's `l` field

### DIFF
--- a/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
+++ b/src/main/scala/awscala/dynamodbv2/AttributeValue.scala
@@ -59,7 +59,7 @@ case class AttributeValue(
     n: Option[String] = None,
     b: Option[ByteBuffer] = None,
     m: Option[JMap[String, aws.model.AttributeValue]] = None,
-    l: Seq[aws.model.AttributeValue],
+    l: Seq[aws.model.AttributeValue] = Nil,
     ss: Seq[String] = Nil,
     ns: Seq[String] = Nil,
     bs: Seq[ByteBuffer] = Nil

--- a/src/main/scala/awscala/dynamodbv2/ResultPager.scala
+++ b/src/main/scala/awscala/dynamodbv2/ResultPager.scala
@@ -47,14 +47,14 @@ sealed trait ResultPager[TReq, TRes] extends Iterator[Item] {
     request match {
       case req: aws.model.QueryRequest =>
         if (req.getSelect == aws.model.Select.COUNT.toString)
-          items = Seq(Item(table, Seq(Attribute("Count", AttributeValue(new AttributeValue(n = Some(getCount(result).toString), l = Nil))))))
+          items = Seq(Item(table, Seq(Attribute("Count", AttributeValue(new AttributeValue(n = Some(getCount(result).toString)))))))
         else {
           invokeCallback(result)
           items = getItems(result).asScala.map(i => Item(table, i))
         }
       case req: aws.model.ScanRequest =>
         if (req.getSelect == aws.model.Select.COUNT.toString)
-          items = Seq(Item(table, Seq(Attribute("Count", AttributeValue(new AttributeValue(n = Some(getCount(result).toString), l = Nil))))))
+          items = Seq(Item(table, Seq(Attribute("Count", AttributeValue(new AttributeValue(n = Some(getCount(result).toString)))))))
         else {
           invokeCallback(result)
           items = getItems(result).asScala.map(i => Item(table, i))


### PR DESCRIPTION
This makes the `AttributeValue` constructor's arguments consistent.

Also removes the (now-redundant) fix introduced in [this commit](https://github.com/seratch/AWScala/commit/ed6b5c4e19d6e79efc895e5bd2a7d35751e39137).

Fixes #140
