### PR TITLE
Set region in S3 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ https://github.com/seratch/awscala/blob/master/src/test/scala/awscala/EC2Spec.sc
 ```scala
 import awscala._, s3._
 
-implicit val s3 = S3()
+implicit val s3 = S3.at(Region.Tokyo)
 
 val buckets: Seq[Bucket] = s3.buckets
 val bucket: Bucket = s3.createBucket("unique-name-xxx")


### PR DESCRIPTION
Set the region in the S3 example to avoid confusion. My requests were timing out until I realized that I needed to set the region. I ended up finding the `at` method by looking at the S3.scala file