### PR TITLE
Adds regions: Seoul, Mumbai, Ningxia, Canada, London, Paris, Ohio

### DIFF
--- a/src/main/scala/awscala/Region0.scala
+++ b/src/main/scala/awscala/Region0.scala
@@ -15,20 +15,38 @@ object Region0 {
   val AP_NORTHEAST_1 = apply(awsregions.Regions.AP_NORTHEAST_1)
   val Tokyo = AP_NORTHEAST_1
 
+  val AP_NORTHEAST_2 = apply(awsregions.Regions.AP_NORTHEAST_2)
+  val Seoul = AP_NORTHEAST_2
+
   val AP_SOUTHEAST_1 = apply(awsregions.Regions.AP_SOUTHEAST_1)
   val Singapore = AP_SOUTHEAST_1
 
   val AP_SOUTHEAST_2 = apply(awsregions.Regions.AP_SOUTHEAST_2)
   val Sydney = AP_SOUTHEAST_2
 
+  val AP_SOUTH_1 = apply(awsregions.Regions.AP_SOUTH_1)
+  val Mumbai = AP_SOUTH_1
+
   val CN_NORTH_1 = apply(awsregions.Regions.CN_NORTH_1)
   val Beijing = CN_NORTH_1
+
+  val CN_NORTHWEST_1 = apply(awsregions.Regions.CN_NORTHWEST_1)
+  val Ningxia = CN_NORTHWEST_1
 
   val EU_CENTRAL_1 = apply(awsregions.Regions.EU_CENTRAL_1)
   val Frankfurt = EU_CENTRAL_1
 
+  val CA_CENTRAL_1 = apply(awsregions.Regions.CA_CENTRAL_1)
+  val Canada = CA_CENTRAL_1
+
   val EU_WEST_1 = apply(awsregions.Regions.EU_WEST_1)
   val Ireland = EU_WEST_1
+
+  val EU_WEST_2 = apply(awsregions.Regions.EU_WEST_2)
+  val London = EU_WEST_2
+
+  val EU_WEST_3 = apply(awsregions.Regions.EU_WEST_3)
+  val Paris = EU_WEST_3
 
   val GovCloud = apply(awsregions.Regions.GovCloud)
 
@@ -38,13 +56,33 @@ object Region0 {
   val US_EAST_1 = apply(awsregions.Regions.US_EAST_1)
   val NorthernVirginia = US_EAST_1
 
+  val US_EAST_2 = apply(awsregions.Regions.US_EAST_2)
+  val Ohio = US_EAST_2
+
   val US_WEST_1 = apply(awsregions.Regions.US_WEST_1)
   val NorthernCalifornia = US_WEST_1
 
   val US_WEST_2 = apply(awsregions.Regions.US_WEST_2)
   val Oregon = US_WEST_2
 
-  lazy val all: Seq[Region] = Seq(Tokyo, Singapore, Sydney, Ireland, GovCloud, SaoPaulo, NorthernVirginia,
-    NorthernCalifornia, Oregon, Frankfurt, Beijing)
+  lazy val all: Seq[Region] = Seq(
+    Tokyo,
+    Seoul,
+    Singapore,
+    Sydney,
+    Mumbai,
+    Beijing,
+    Ningxia,
+    Frankfurt,
+    Canada,
+    Ireland,
+    London,
+    Paris,
+    GovCloud,
+    SaoPaulo,
+    NorthernVirginia,
+    Ohio,
+    NorthernCalifornia,
+    Oregon)
 
 }

--- a/src/test/scala/awscala/RegionSpec.scala
+++ b/src/test/scala/awscala/RegionSpec.scala
@@ -1,0 +1,20 @@
+package awscala
+
+import org.scalatest.{ FlatSpec, Matchers }
+
+import com.amazonaws.regions.{ Regions => AwsRegions }
+
+class RegionSpec extends FlatSpec with Matchers {
+
+  behavior of "Region0"
+
+  it should "have all of the regions defined" in {
+    val regionsFromAws = AwsRegions.values().map(_.getName.toUpperCase).sorted
+
+    val regionsFromAwsScala = Region0.all.toArray.map(_.getName.toUpperCase).sorted
+
+    regionsFromAwsScala should contain theSameElementsAs regionsFromAws
+
+  }
+
+}


### PR DESCRIPTION
Also adds a test to ensure that the regions available in the AWS SDK are reflected on the Scala side.

Note that this does NOT update the AWS SDK to the latest (1.11.285). That version does not yet have `ap-northeast-3` available.

Fixes #142