### PR TITLE
Lets developers use AWS providers to authenticate AWScala clients

### DIFF
--- a/dynamodb/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
+++ b/dynamodb/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
@@ -3,6 +3,7 @@ package awscala.dynamodbv2
 import awscala._
 import scala.collection.JavaConverters._
 import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.{ dynamodbv2 => aws }
 import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes
 
@@ -10,11 +11,11 @@ object DynamoDB {
 
   def apply(credentials: Credentials)(implicit region: Region): DynamoDB = apply(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey))(region)
   def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): DynamoDB = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey))(region)
-  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): DynamoDB = new DynamoDBClient(credentialsProvider).at(region)
+  def apply(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): DynamoDB = new DynamoDBClient(credentialsProvider).at(region)
 
   def apply(clientConfiguration: ClientConfiguration, credentials: Credentials)(implicit region: Region): DynamoDB = apply(clientConfiguration, BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey))(region)
   def apply(clientConfiguration: ClientConfiguration, accessKeyId: String, secretAccessKey: String)(implicit region: Region): DynamoDB = apply(clientConfiguration, BasicCredentialsProvider(accessKeyId, secretAccessKey))(region)
-  def apply(clientConfiguration: ClientConfiguration, credentialsProvider: CredentialsProvider)(implicit region: Region): DynamoDB = new ConfiguredDynamoDBClient(clientConfiguration, credentialsProvider).at(region)
+  def apply(clientConfiguration: ClientConfiguration, credentialsProvider: AWSCredentialsProvider)(implicit region: Region): DynamoDB = new ConfiguredDynamoDBClient(clientConfiguration, credentialsProvider).at(region)
 
   def at(region: Region): DynamoDB = apply()(region)
 
@@ -363,7 +364,7 @@ trait DynamoDB extends aws.AmazonDynamoDB {
  *
  * @param credentialsProvider credentialsProvider
  */
-class DynamoDBClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+class DynamoDBClient(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AmazonDynamoDBClient(credentialsProvider)
   with DynamoDB
 
@@ -373,6 +374,6 @@ class DynamoDBClient(credentialsProvider: CredentialsProvider = CredentialsLoade
  * @param clientConfiguration clientConfiguration
  * @param credentialsProvider credentialsProvider
  */
-class ConfiguredDynamoDBClient(clientConfiguration: ClientConfiguration, credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+class ConfiguredDynamoDBClient(clientConfiguration: ClientConfiguration, credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AmazonDynamoDBClient(credentialsProvider, clientConfiguration)
   with DynamoDB

--- a/ec2/src/main/scala/awscala/ec2/EC2.scala
+++ b/ec2/src/main/scala/awscala/ec2/EC2.scala
@@ -2,13 +2,14 @@ package awscala.ec2
 
 import awscala._
 import scala.collection.JavaConverters._
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.{ ec2 => aws }
 import scala.annotation.tailrec
 
 object EC2 {
 
   def apply(credentials: Credentials)(implicit region: Region): EC2 = new EC2Client(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
-  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): EC2 = new EC2Client(credentialsProvider).at(region)
+  def apply(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): EC2 = new EC2Client(credentialsProvider).at(region)
   def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): EC2 = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
 
   def at(region: Region): EC2 = apply()(region)
@@ -161,6 +162,6 @@ trait EC2 extends aws.AmazonEC2Async {
  *
  * @param credentialsProvider credentialsProvider
  */
-class EC2Client(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+class EC2Client(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AmazonEC2AsyncClient(credentialsProvider)
   with EC2

--- a/emr/src/main/scala/awscala/emr/EMR.scala
+++ b/emr/src/main/scala/awscala/emr/EMR.scala
@@ -5,12 +5,13 @@ import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.{ elasticmapreduce => aws }
 import aws.model._
 
 object EMR {
   def apply(credentials: Credentials)(implicit region: Region): EMR = new EMRClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
-  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): EMR = new EMRClient(credentialsProvider).at(region)
+  def apply(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): EMR = new EMRClient(credentialsProvider).at(region)
   def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): EMR = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
   def at(region: Region): EMR = apply()(region)
 }
@@ -270,4 +271,4 @@ trait EMR extends aws.AmazonElasticMapReduce {
 
 }
 
-class EMRClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load()) extends aws.AmazonElasticMapReduceClient(credentialsProvider) with EMR
+class EMRClient(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load()) extends aws.AmazonElasticMapReduceClient(credentialsProvider) with EMR

--- a/iam/src/main/scala/awscala/iam/IAM.scala
+++ b/iam/src/main/scala/awscala/iam/IAM.scala
@@ -2,11 +2,12 @@ package awscala.iam
 
 import awscala._
 import scala.collection.JavaConverters._
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.{ identitymanagement => aws }
 
 object IAM {
   def apply(credentials: Credentials): IAM = new IAMClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey))
-  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load()): IAM = new IAMClient(credentialsProvider)
+  def apply(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load()): IAM = new IAMClient(credentialsProvider)
   def apply(accessKeyId: String, secretAccessKey: String): IAM = {
     new IAMClient(BasicCredentialsProvider(accessKeyId, secretAccessKey))
   }
@@ -324,6 +325,6 @@ trait IAM extends aws.AmazonIdentityManagement {
  *
  * @param credentialsProvider credentialsProvider
  */
-class IAMClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+class IAMClient(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AmazonIdentityManagementClient(credentialsProvider)
   with IAM

--- a/redshift/src/main/scala/awscala/redshift/Redshift.scala
+++ b/redshift/src/main/scala/awscala/redshift/Redshift.scala
@@ -2,13 +2,14 @@ package awscala.redshift
 
 import awscala._
 import scala.collection.JavaConverters._
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.{ redshift => aws }
 
 object Redshift {
 
   def apply(credentials: Credentials)(implicit region: Region): Redshift = new RedshiftClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
 
-  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): Redshift = new RedshiftClient(credentialsProvider).at(region)
+  def apply(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): Redshift = new RedshiftClient(credentialsProvider).at(region)
 
   def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): Redshift = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
 
@@ -311,7 +312,7 @@ trait Redshift extends aws.AmazonRedshift {
  *
  * @param credentialsProvider credentialsProvider
  */
-class RedshiftClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+class RedshiftClient(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AmazonRedshiftClient(credentialsProvider)
   with Redshift
 

--- a/s3/src/main/scala/awscala/s3/S3.scala
+++ b/s3/src/main/scala/awscala/s3/S3.scala
@@ -4,6 +4,7 @@ import java.io.{ ByteArrayInputStream, File, InputStream }
 
 import awscala._
 import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.{ s3 => aws }
 
 import scala.annotation.tailrec
@@ -15,13 +16,13 @@ object S3 {
 
   def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): S3 = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey))(region)
 
-  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): S3 = new S3Client(credentialsProvider).at(region)
+  def apply(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): S3 = new S3Client(credentialsProvider).at(region)
 
   def apply(clientConfiguration: ClientConfiguration, credentials: Credentials)(implicit region: Region): S3 = apply(clientConfiguration, BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey))(region)
 
   def apply(clientConfiguration: ClientConfiguration, accessKeyId: String, secretAccessKey: String)(implicit region: Region): S3 = apply(clientConfiguration, BasicCredentialsProvider(accessKeyId, secretAccessKey))(region)
 
-  def apply(clientConfiguration: ClientConfiguration, credentialsProvider: CredentialsProvider)(implicit region: Region): S3 = new ConfiguredS3Client(clientConfiguration, credentialsProvider).at(region)
+  def apply(clientConfiguration: ClientConfiguration, credentialsProvider: AWSCredentialsProvider)(implicit region: Region): S3 = new ConfiguredS3Client(clientConfiguration, credentialsProvider).at(region)
 
   def at(region: Region): S3 = apply()(region)
 }
@@ -333,7 +334,7 @@ trait S3 extends aws.AmazonS3 {
  *
  * @param credentialsProvider credentialsProvider
  */
-class S3Client(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+class S3Client(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AmazonS3Client(credentialsProvider)
   with S3 {
 
@@ -346,7 +347,7 @@ class S3Client(credentialsProvider: CredentialsProvider = CredentialsLoader.load
  * @param clientConfiguration ClientConfiguration
  * @param credentialsProvider CredentialsProvider
  */
-class ConfiguredS3Client(clientConfiguration: ClientConfiguration, credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+class ConfiguredS3Client(clientConfiguration: ClientConfiguration, credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AmazonS3Client(credentialsProvider, clientConfiguration)
   with S3 {
 

--- a/simpledb/src/main/scala/awscala/simpledb/SimpleDB.scala
+++ b/simpledb/src/main/scala/awscala/simpledb/SimpleDB.scala
@@ -2,13 +2,14 @@ package awscala.simpledb
 
 import awscala._
 import scala.collection.JavaConverters._
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.{ simpledb => aws }
 import com.amazonaws.services.simpledb.model.ListDomainsRequest
 
 object SimpleDB {
 
   def apply(credentials: Credentials)(implicit region: Region): SimpleDB = new SimpleDBClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
-  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): SimpleDB = new SimpleDBClient(credentialsProvider).at(region)
+  def apply(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): SimpleDB = new SimpleDBClient(credentialsProvider).at(region)
   def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): SimpleDB = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
 
   def at(region: Region): SimpleDB = apply()(region)
@@ -121,7 +122,7 @@ trait SimpleDB extends aws.AmazonSimpleDB {
  *
  * @param credentialsProvider credentialsProvider
  */
-class SimpleDBClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+class SimpleDBClient(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AmazonSimpleDBClient(credentialsProvider)
   with SimpleDB
 

--- a/sqs/src/main/scala/awscala/sqs/SQS.scala
+++ b/sqs/src/main/scala/awscala/sqs/SQS.scala
@@ -3,12 +3,12 @@ package awscala.sqs
 import awscala._
 import scala.collection.JavaConverters._
 import com.amazonaws.services.{ sqs => aws }
-import com.amazonaws.auth.AWSSessionCredentials
+import com.amazonaws.auth.{ AWSCredentialsProvider, AWSSessionCredentials }
 
 object SQS {
 
   def apply(credentials: Credentials)(implicit region: Region): SQS = new SQSClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey)).at(region)
-  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): SQS = new SQSClient(credentialsProvider).at(region)
+  def apply(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())(implicit region: Region = Region.default()): SQS = new SQSClient(credentialsProvider).at(region)
   def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): SQS = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey)).at(region)
 
   def at(region: Region): SQS = apply()(region)
@@ -137,7 +137,7 @@ class SQSClientWithQueue(sqs: SQS, queue: Queue) {
  *
  * @param credentialsProvider credentialsProvider
  */
-class SQSClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+class SQSClient(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AmazonSQSClient(credentialsProvider)
   with SQS
 

--- a/stepfunctions/src/main/scala/awscala/stepfunctions/StepFunctions.scala
+++ b/stepfunctions/src/main/scala/awscala/stepfunctions/StepFunctions.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit
 
 import awscala._
 import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.stepfunctions.model._
 import com.amazonaws.services.{ stepfunctions => aws }
 
@@ -21,7 +22,7 @@ object StepFunctions {
   def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): StepFunctions =
     apply(BasicCredentialsProvider(accessKeyId, secretAccessKey))(region)
 
-  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load())(
+  def apply(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())(
     implicit
     region: Region = Region.default()): StepFunctions =
     new StepFunctionsClient(new ClientConfiguration().withSocketTimeout(DEFAULT_SOCKET_TIMEOUT), credentialsProvider)
@@ -38,7 +39,7 @@ object StepFunctions {
     region: Region): StepFunctions =
     apply(clientConfiguration, BasicCredentialsProvider(accessKeyId, secretAccessKey))(region)
 
-  def apply(clientConfiguration: ClientConfiguration, credentialsProvider: CredentialsProvider)(
+  def apply(clientConfiguration: ClientConfiguration, credentialsProvider: AWSCredentialsProvider)(
     implicit
     region: Region): StepFunctions =
     new StepFunctionsClient(
@@ -130,6 +131,6 @@ trait StepFunctions extends aws.AWSStepFunctions {
 
 class StepFunctionsClient(
   clientConfiguration: ClientConfiguration,
-  credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+  credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AWSStepFunctionsClient(credentialsProvider, clientConfiguration)
   with StepFunctions

--- a/sts/src/main/scala/awscala/sts/STS.scala
+++ b/sts/src/main/scala/awscala/sts/STS.scala
@@ -1,13 +1,14 @@
 package awscala.sts
 
 import awscala._
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.{ securitytoken => aws }
 import com.amazonaws.util.json.Jackson
 import java.net._
 
 object STS {
   def apply(credentials: Credentials)(implicit region: Region): STS = new STSClient(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey))
-  def apply(credentialsProvider: CredentialsProvider = CredentialsLoader.load()): STS = new STSClient(credentialsProvider)
+  def apply(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load()): STS = new STSClient(credentialsProvider)
   def apply(accessKeyId: String, secretAccessKey: String): STS = {
     new STSClient(BasicCredentialsProvider(accessKeyId, secretAccessKey))
   }
@@ -75,6 +76,6 @@ trait STS extends aws.AWSSecurityTokenService {
  *
  * @param credentialsProvider credentialsProvider
  */
-class STSClient(credentialsProvider: CredentialsProvider = CredentialsLoader.load())
+class STSClient(credentialsProvider: AWSCredentialsProvider = CredentialsLoader.load())
   extends aws.AWSSecurityTokenServiceClient(credentialsProvider)
   with STS


### PR DESCRIPTION
Enables the use of AWSProviderChains with AWScala by allowing use of AWS own providers as well as those offered by AWScala. This is backwards compatible with existing versions 

See #128 for detailed info about the problem being solved, this is a suggestion for a minimal change that addresses that issue to kick of a conversation there.
