### PR TITLE
Removed the usage of deprecated method.

### DIFF
--- a/ec2/src/main/scala/awscala/ec2/Requests.scala
+++ b/ec2/src/main/scala/awscala/ec2/Requests.scala
@@ -46,7 +46,7 @@ object IpPermission {
     IpPermission(
       fromPort = if (i.getFromPort == null) -1 else i.getFromPort,
       toPort = if (i.getToPort == null) -1 else i.getToPort,
-      ipRanges = i.getIpRanges.asScala,
+      ipRanges = i.getIpv4Ranges.asScala.map(_.getCidrIp),
       ipProtocol = i.getIpProtocol,
       userIdGroupPairs = i.getUserIdGroupPairs.asScala.map(UserIdGroupPair(_)))
 


### PR DESCRIPTION
Modifications:
- Changed the deprecated `getIpRanges()` method to `getIpv4Ranges()`.

References:
- [EC2 - IpRange](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_IpRange.html)