### PR TITLE
fix: "cannot create enum from eu-north-1-value"

### DIFF
--- a/core/src/main/scala/awscala/Region0.scala
+++ b/core/src/main/scala/awscala/Region0.scala
@@ -9,7 +9,14 @@ object Region0 {
   def default(): Region = defaultRegion
   def default(region: Region): Unit = defaultRegion = region
 
-  def apply(name: String): Region = apply(awsregions.Regions.fromName(name))
+  def apply(name: String): Region = {
+    try {
+      apply(awsregions.Regions.fromName(name))
+    } catch {
+      case _: IllegalArgumentException => null
+    }
+  }
+
   def apply(name: awsregions.Regions): Region = awsregions.Region.getRegion(name)
 
   val AP_NORTHEAST_1 = apply(awsregions.Regions.AP_NORTHEAST_1)


### PR DESCRIPTION
It is related to #210.

If EMR version is low, IllegalArgumentException is raised.

It is because when calling the apply function by name as a string, if name is not in Regions, the exception is raised.

So, I've fixed the bug. In my code, when raising the exception, null is returned like "def apply(name: awsregions.Regions): Region".

email: keunhyun.oh@ahnlab.com
