### PR TITLE
dynamo - batchget by composite key

### DIFF
--- a/dynamodb/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
+++ b/dynamodb/src/main/scala/awscala/dynamodbv2/DynamoDB.scala
@@ -3,6 +3,7 @@ package awscala.dynamodbv2
 import java.util
 
 import awscala._
+import DynamoDB._
 
 import scala.jdk.CollectionConverters._
 import com.amazonaws.ClientConfiguration
@@ -11,6 +12,8 @@ import com.amazonaws.services.{ dynamodbv2 => aws }
 import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes
 
 object DynamoDB {
+  type SimplePk = (String, Any)
+  type CompositePk = (String, Any, String, Any)
 
   def apply(credentials: Credentials)(implicit region: Region): DynamoDB = apply(BasicCredentialsProvider(credentials.getAWSAccessKeyId, credentials.getAWSSecretKey))(region)
   def apply(accessKeyId: String, secretAccessKey: String)(implicit region: Region): DynamoDB = apply(BasicCredentialsProvider(accessKeyId, secretAccessKey))(region)
@@ -26,6 +29,29 @@ object DynamoDB {
     val client = DynamoDB("", "")(Region.default())
     client.setEndpoint("http://localhost:8000")
     client
+  }
+
+  private[dynamodbv2] object BatchGet {
+
+    def toJavaForSimplePk(tableAndAttributes: Map[Table, List[SimplePk]]): util.Map[String, KeysAndAttributes] =
+      tableAndAttributes.map {
+        case (table, attributes) =>
+          table.name -> new KeysAndAttributes().withKeys(
+            attributes.map {
+              case (k, v) => Map(k -> AttributeValue.toJavaValue(v)).asJava
+            }.asJava)
+      }.asJava
+
+    def toJavaForCompositePk(tableAndAttributes: Map[Table, List[CompositePk]]): util.Map[String, KeysAndAttributes] =
+      tableAndAttributes.map {
+        case (table, attributes) =>
+          table.name -> new KeysAndAttributes().withKeys(
+            attributes.map {
+              case (partition, pv, sort, sv) => Map(
+                partition -> AttributeValue.toJavaValue(pv),
+                sort -> AttributeValue.toJavaValue(sv)).asJava
+            }.asJava)
+      }.asJava
   }
 }
 
@@ -162,7 +188,9 @@ trait DynamoDB extends aws.AmazonDynamoDB {
     }
   }
 
-  def batchGet(tableAndAttributes: Map[Table, List[(String, Any)]]): Seq[Item] = {
+  def batchGet[T](
+    tableAndAttributes: Map[Table, List[T]],
+    toJava: Map[Table, List[T]] => util.Map[String, KeysAndAttributes]): Seq[Item] = {
     import com.amazonaws.services.dynamodbv2.model.{ BatchGetItemRequest, BatchGetItemResult }
 
     case class State(items: List[Item], keys: java.util.Map[String, KeysAndAttributes])
@@ -189,72 +217,63 @@ trait DynamoDB extends aws.AmazonDynamoDB {
       }
     }
 
-    def toJava(tableAndAttributes: Map[Table, List[(String, Any)]]): util.Map[String, KeysAndAttributes] =
-      tableAndAttributes.map {
-        case (table, attributes) =>
-          table.name -> new KeysAndAttributes().withKeys(
-            attributes.map {
-              case (k, v) => Map(k -> AttributeValue.toJavaValue(v)).asJava
-            }.asJava)
-      }.asJava
-
     toStream(State(Nil, toJava(tableAndAttributes)))
   }
 
-  def put(table: Table, hashPK: Any, attributes: (String, Any)*): Unit = {
+  def put(table: Table, hashPK: Any, attributes: SimplePk*): Unit = {
     putItem(table, hashPK, attributes: _*)
   }
-  def putItem(table: Table, hashPK: Any, attributes: (String, Any)*): Unit = {
+  def putItem(table: Table, hashPK: Any, attributes: SimplePk*): Unit = {
     put(table, Seq(table.hashPK -> hashPK) ++: attributes: _*)
   }
 
-  def put(table: Table, hashPK: Any, rangePK: Any, attributes: (String, Any)*): Unit = {
+  def put(table: Table, hashPK: Any, rangePK: Any, attributes: SimplePk*): Unit = {
     putItem(table, hashPK, rangePK, attributes: _*)
   }
-  def putItem(table: Table, hashPK: Any, rangePK: Any, attributes: (String, Any)*): Unit = {
+  def putItem(table: Table, hashPK: Any, rangePK: Any, attributes: SimplePk*): Unit = {
     put(table, Seq(table.hashPK -> hashPK, table.rangePK.get -> rangePK) ++: attributes: _*)
   }
 
-  def attributeValues(attributes: Seq[(String, Any)]): java.util.Map[String, aws.model.AttributeValue] =
+  def attributeValues(attributes: Seq[SimplePk]): java.util.Map[String, aws.model.AttributeValue] =
     attributes.toMap.mapValues(AttributeValue.toJavaValue(_)).toMap.asJava
 
-  def put(table: Table, attributes: (String, Any)*): Unit = putItem(table.name, attributes: _*)
-  def putItem(tableName: String, attributes: (String, Any)*): Unit = {
+  def put(table: Table, attributes: SimplePk*): Unit = putItem(table.name, attributes: _*)
+  def putItem(tableName: String, attributes: SimplePk*): Unit = {
     putItem(new aws.model.PutItemRequest()
       .withTableName(tableName)
       .withItem(attributeValues(attributes.toSeq)))
   }
 
-  def putConditional(tableName: String, attributes: (String, Any)*)(cond: Seq[(String, aws.model.ExpectedAttributeValue)]): Unit = {
+  def putConditional(tableName: String, attributes: SimplePk*)(cond: Seq[(String, aws.model.ExpectedAttributeValue)]): Unit = {
     putItem(new aws.model.PutItemRequest()
       .withTableName(tableName)
       .withItem(attributeValues(attributes.toSeq))
       .withExpected(cond.toMap.asJava))
   }
 
-  def addAttributes(table: Table, hashPK: Any, attributes: (String, Any)*): Unit = {
+  def addAttributes(table: Table, hashPK: Any, attributes: SimplePk*): Unit = {
     updateAttributes(table, hashPK, None, aws.model.AttributeAction.ADD, attributes.toSeq)
   }
-  def addAttributes(table: Table, hashPK: Any, rangePK: Any, attributes: (String, Any)*): Unit = {
+  def addAttributes(table: Table, hashPK: Any, rangePK: Any, attributes: SimplePk*): Unit = {
     updateAttributes(table, hashPK, Some(rangePK), aws.model.AttributeAction.ADD, attributes.toSeq)
   }
 
-  def deleteAttributes(table: Table, hashPK: Any, attributes: (String, Any)*): Unit = {
+  def deleteAttributes(table: Table, hashPK: Any, attributes: SimplePk*): Unit = {
     updateAttributes(table, hashPK, None, aws.model.AttributeAction.DELETE, attributes.toSeq)
   }
-  def deleteAttributes(table: Table, hashPK: Any, rangePK: Any, attributes: (String, Any)*): Unit = {
+  def deleteAttributes(table: Table, hashPK: Any, rangePK: Any, attributes: SimplePk*): Unit = {
     updateAttributes(table, hashPK, Some(rangePK), aws.model.AttributeAction.DELETE, attributes.toSeq)
   }
 
-  def putAttributes(table: Table, hashPK: Any, attributes: (String, Any)*): Unit = {
+  def putAttributes(table: Table, hashPK: Any, attributes: SimplePk*): Unit = {
     updateAttributes(table, hashPK, None, aws.model.AttributeAction.PUT, attributes.toSeq)
   }
-  def putAttributes(table: Table, hashPK: Any, rangePK: Any, attributes: (String, Any)*): Unit = {
+  def putAttributes(table: Table, hashPK: Any, rangePK: Any, attributes: SimplePk*): Unit = {
     updateAttributes(table, hashPK, Some(rangePK), aws.model.AttributeAction.PUT, attributes.toSeq)
   }
 
   private[dynamodbv2] def updateAttributes(
-    table: Table, hashPK: Any, rangePK: Option[Any], action: AttributeAction, attributes: Seq[(String, Any)]): Unit = {
+    table: Table, hashPK: Any, rangePK: Option[Any], action: AttributeAction, attributes: Seq[SimplePk]): Unit = {
 
     val tableKeys = Map(table.hashPK -> AttributeValue.toJavaValue(hashPK)) ++ rangePK.flatMap(rKey => table.rangePK.map(_ -> AttributeValue.toJavaValue(rKey)))
 

--- a/dynamodb/src/main/scala/awscala/dynamodbv2/Table.scala
+++ b/dynamodb/src/main/scala/awscala/dynamodbv2/Table.scala
@@ -1,12 +1,15 @@
 package awscala.dynamodbv2
 
+import DynamoDB.{ SimplePk, CompositePk }
+
 import java.lang.reflect.Modifier
 
-import com.amazonaws.services.{dynamodbv2 => aws}
+import com.amazonaws.services.{ dynamodbv2 => aws }
 
 import scala.reflect.ClassTag
 
 object Table {
+
   def apply(
     name: String,
     hashPK: String,
@@ -46,14 +49,20 @@ case class Table(
     dynamoDB.get(this, hashPK, rangePK)
   }
 
-  def batchGet(attributes: List[(String, Any)])(implicit dynamoDB: DynamoDB): Seq[Item] = batchGetItems(attributes)
+  def batchGet(attributes: List[SimplePk])(implicit dynamoDB: DynamoDB): Seq[Item] =
+    batchGetItems(attributes)
 
-  def batchGetItems(attributes: List[(String, Any)])(implicit dynamoDB: DynamoDB): Seq[Item] = {
-    dynamoDB.batchGet(Map(this -> attributes))
-  }
+  def batchGet(attributes: List[CompositePk])(implicit dynamoDB: DynamoDB, di: DummyImplicit): Seq[Item] =
+    batchGetItems(attributes)
 
-  def put(hashPK: Any, attributes: (String, Any)*)(implicit dynamoDB: DynamoDB): Unit = putItem(hashPK, attributes: _*)
-  def put(hashPK: Any, rangePK: Any, attributes: (String, Any)*)(implicit dynamoDB: DynamoDB): Unit = putItem(hashPK, rangePK, attributes: _*)
+  def batchGetItems(attributes: List[SimplePk])(implicit dynamoDB: DynamoDB): Seq[Item] =
+    dynamoDB.batchGet[SimplePk](Map(this -> attributes), DynamoDB.BatchGet.toJavaForSimplePk)
+
+  def batchGetItems(attributes: List[CompositePk])(implicit dynamoDB: DynamoDB, di: DummyImplicit): Seq[Item] =
+    dynamoDB.batchGet[CompositePk](Map(this -> attributes), DynamoDB.BatchGet.toJavaForCompositePk)
+
+  def put(hashPK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = putItem(hashPK, attributes: _*)
+  def put(hashPK: Any, rangePK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = putItem(hashPK, rangePK, attributes: _*)
 
   def putItem[E <: AnyRef](entity: E)(implicit dynamoDB: DynamoDB): Unit = {
     val attrs = getAttrValuesToMap(entity, true)
@@ -103,12 +112,10 @@ case class Table(
     methodNames.filter(m => fieldNames.contains(m))
   }
 
-
-
-  def putItem(hashPK: Any, attributes: (String, Any)*)(implicit dynamoDB: DynamoDB): Unit = {
+  def putItem(hashPK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = {
     dynamoDB.put(this, hashPK, attributes: _*)
   }
-  def putItem(hashPK: Any, rangePK: Any, attributes: (String, Any)*)(implicit dynamoDB: DynamoDB): Unit = {
+  def putItem(hashPK: Any, rangePK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = {
     dynamoDB.put(this, hashPK, rangePK, attributes: _*)
   }
 
@@ -183,34 +190,34 @@ case class Table(
       pageStatsCallback = pageStatsCallback)
   }
 
-  def addAttributes(hashPK: Any, attributes: (String, Any)*)(
+  def addAttributes(hashPK: Any, attributes: SimplePk*)(
     implicit
     dynamoDB: DynamoDB): Unit = {
     dynamoDB.updateAttributes(this, hashPK, None, aws.model.AttributeAction.ADD, attributes)
   }
-  def addAttributes(hashPK: Any, rangePK: Any, attributes: Seq[(String, Any)])(
+  def addAttributes(hashPK: Any, rangePK: Any, attributes: Seq[SimplePk])(
     implicit
     dynamoDB: DynamoDB): Unit = {
     dynamoDB.updateAttributes(this, hashPK, Some(rangePK), aws.model.AttributeAction.ADD, attributes)
   }
 
-  def deleteAttributes(hashPK: Any, attributes: Seq[(String, Any)])(
+  def deleteAttributes(hashPK: Any, attributes: Seq[SimplePk])(
     implicit
     dynamoDB: DynamoDB): Unit = {
     dynamoDB.updateAttributes(this, hashPK, None, aws.model.AttributeAction.DELETE, attributes)
   }
-  def deleteAttributes(hashPK: Any, rangePK: Any, attributes: Seq[(String, Any)])(
+  def deleteAttributes(hashPK: Any, rangePK: Any, attributes: Seq[SimplePk])(
     implicit
     dynamoDB: DynamoDB): Unit = {
     dynamoDB.updateAttributes(this, hashPK, Some(rangePK), aws.model.AttributeAction.DELETE, attributes)
   }
 
-  def putAttributes(hashPK: Any, attributes: Seq[(String, Any)])(
+  def putAttributes(hashPK: Any, attributes: Seq[SimplePk])(
     implicit
     dynamoDB: DynamoDB): Unit = {
     dynamoDB.updateAttributes(this, hashPK, None, aws.model.AttributeAction.PUT, attributes)
   }
-  def putAttributes(hashPK: Any, rangePK: Any, attributes: Seq[(String, Any)])(
+  def putAttributes(hashPK: Any, rangePK: Any, attributes: Seq[SimplePk])(
     implicit
     dynamoDB: DynamoDB): Unit = {
     dynamoDB.updateAttributes(this, hashPK, Some(rangePK), aws.model.AttributeAction.PUT, attributes)

--- a/dynamodb/src/main/scala/awscala/dynamodbv2/Table.scala
+++ b/dynamodb/src/main/scala/awscala/dynamodbv2/Table.scala
@@ -56,10 +56,10 @@ case class Table(
     batchGetItems(attributes)
 
   def batchGetItems(attributes: List[SimplePk])(implicit dynamoDB: DynamoDB): Seq[Item] =
-    dynamoDB.batchGet[SimplePk](Map(this -> attributes), DynamoDB.BatchGet.toJavaForSimplePk)
+    dynamoDB.batchGet[SimplePk](Map(this -> attributes))
 
   def batchGetItems(attributes: List[CompositePk])(implicit dynamoDB: DynamoDB, di: DummyImplicit): Seq[Item] =
-    dynamoDB.batchGet[CompositePk](Map(this -> attributes), DynamoDB.BatchGet.toJavaForCompositePk)
+    dynamoDB.batchGet[CompositePk](Map(this -> attributes))
 
   def put(hashPK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = putItem(hashPK, attributes: _*)
   def put(hashPK: Any, rangePK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = putItem(hashPK, rangePK, attributes: _*)


### PR DESCRIPTION
This PR adds an overloaded method to DynamoDb to allow batch gets on tables with composite primary keys.

Some call outs:

1) I created two types: `SimplePk` and `CompositePk` in the DynamoDb companion
2) I added additional tests.

All tests are passing.