### PR TITLE
Support Scala 3.0.0-RC3

### DIFF
--- a/ec2/src/main/scala/awscala/ec2/SSHEnabledInstance.scala
+++ b/ec2/src/main/scala/awscala/ec2/SSHEnabledInstance.scala
@@ -3,7 +3,7 @@ package awscala.ec2
 import com.decodified.scalassh._
 import java.io.File
 
-case class SSHEnabledInstance(instance: Instance) extends {
+case class SSHEnabledInstance(instance: Instance) {
 
   def ssh[T](f: SshClient => SSH.Result[T], keyPairFilePath: String): SSH.Result[T] = ssh(f, new File(keyPairFilePath))
 

--- a/emr/src/test/scala/awscala/EMRSpec.scala
+++ b/emr/src/test/scala/awscala/EMRSpec.scala
@@ -15,7 +15,7 @@ class EMRSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   val keyPairName = s"awscala-emr-test-keypair-${System.currentTimeMillis}-${new scala.util.Random().nextInt(100)}"
 
   val awsRegion = Region.US_EAST_1
-  implicit val ec2 = EC2.at(awsRegion)
+  implicit val ec2: EC2 = EC2.at(awsRegion)
 
   override def beforeAll(): Unit = {
     ec2.createKeyPair(keyPairName)
@@ -25,7 +25,7 @@ class EMRSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     ec2.deleteKeyPair(keyPairName)
   }
 
-  implicit val emr = EMR.at(awsRegion)
+  implicit val emr: EMR = EMR.at(awsRegion)
   val log = LoggerFactory.getLogger(this.getClass)
 
   // Basically we dont' support this module, please contact @CruncherBigData.

--- a/s3/src/main/scala/awscala/s3/S3.scala
+++ b/s3/src/main/scala/awscala/s3/S3.scala
@@ -45,7 +45,7 @@ trait S3 extends aws.AmazonS3 {
     }
   }
 
-  private[this] var region: aws.model.Region = aws.model.Region.fromValue(s3RegionHack(Region.default.getName))
+  private[this] var region: aws.model.Region = aws.model.Region.fromValue(s3RegionHack(Region.default().getName))
 
   def at(region: Region): S3 = {
     this.setRegion(region)

--- a/s3/src/test/scala/awscala/S3Spec.scala
+++ b/s3/src/test/scala/awscala/S3Spec.scala
@@ -58,7 +58,7 @@ class S3Spec extends AnyFlatSpec with Matchers {
     // get objects
     val s3obj: Option[S3Object] = bucket.get("S3.scala")
     log.info(s"Object: ${s3obj}")
-    val summaries = bucket.objectSummaries
+    val summaries = bucket.objectSummaries()
     log.info(s"Object Summaries: ${summaries}")
 
     // delete objects


### PR DESCRIPTION
This doesn't add Scala 3 support for the DynamoDB module, as that uses reflection that would take more careful attention to port.

For the ec2 module it uses cross-version compatibility for the scala-ssh dependency. I've opened a [PR](https://github.com/sirthias/scala-ssh/pull/55) to build scala-ssh for Scala 3, but in the meantime the cross-version use shouldn't cause any problems for library users since scala-ssh doesn't bring in any transitive Scala-based dependencies.