### PR TITLE
Fix dynamodb putItem for annotated case classes

### DIFF
--- a/dynamodb/src/main/scala/awscala/dynamodbv2/Table.scala
+++ b/dynamodb/src/main/scala/awscala/dynamodbv2/Table.scala
@@ -81,12 +81,12 @@ case class Table(
     var maybeHashPK: Option[Any] = None
     var maybeRangePK: Option[Any] = None
     val attributes: ListBuffer[(String, AnyRef)] = ListBuffer()
-    for (arg <- constructorArgs) {
-      getterCallResults.find { case (name, _) => name == arg.name } match {
-        case Some((_, value)) if arg.annotationNames.contains("hashPK") => maybeHashPK = Some(value)
-        case Some((_, value)) if arg.annotationNames.contains("rangePK") => maybeRangePK = Some(value)
-        case Some(nameAndValue) => attributes += nameAndValue
-        case _ => // noop
+    for (nameAndValue <- getterCallResults) {
+      val (name, value) = nameAndValue
+      constructorArgs.find { arg => name == arg.name } match {
+        case Some(arg) if arg.annotationNames.exists(_.contains("hashPK")) => maybeHashPK = Some(value)
+        case Some(arg) if arg.annotationNames.exists(_.contains("rangePK")) => maybeRangePK = Some(value)
+        case _ => attributes += nameAndValue
       }
     }
     (maybeHashPK, maybeRangePK) match {


### PR DESCRIPTION
`DynamoDBV2Spec` fails for me since the changes in #236 - Apparently the tests pass on other machines, but these changes should make the logic more robust.