### PR TITLE
Scala 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ val googlers: Seq[Item] = table.scan(Seq("Company" -> cond.eq("Google")))
 table.destroy()
 ```
 
-PUT method with case class usage
+PUT method with case class usage (@hashPK and @rangePK annotations are not currently available in Scala 3)
 
 ```scala
 import awscala._, dynamodbv2._ 

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,14 @@
 import xerial.sbt.Sonatype.autoImport._
 
 val scala213 = "2.13.4"
-val scala3 = "3.0.0-RC3"
+val scala3 = "3.0.0"
 
 lazy val commonSettings = Seq(
   organization := "com.github.seratch",
   name := "awscala",
   version := "0.9.1",
   scalaVersion := scala213,
-  // TODO: set scala3 for all projects
-  crossScalaVersions := Seq(scala213),
+  crossScalaVersions := Seq(scala213, scala3),
   sbtPlugin := false,
   transitiveClassifiers in Global := Seq(Artifact.SourceClassifier),
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
@@ -74,10 +73,10 @@ lazy val core = project
       "com.amazonaws" % "aws-java-sdk-core" % awsJavaSdkVersion,
       "joda-time" % "joda-time" % "2.10.10",
       "org.joda" % "joda-convert" % "2.2.1",
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.3",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.4",
       "org.bouncycastle" % "bcprov-jdk16" % "1.46" % "provided",
       "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
-      "org.scalatest" %% "scalatest" % "3.2.8" % "test",
+      "org.scalatest" %% "scalatest" % "3.2.9" % "test",
     ) ++ {scalaVersion.value.head match {
       case '2' => Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
       case _ => Seq()
@@ -87,19 +86,19 @@ lazy val core = project
 lazy val ec2 = awsProject("ec2")
   .settings(
     libraryDependencies ++= Seq(
-      ("com.decodified" %% "scala-ssh" % "0.11.0" % "provided").cross(CrossVersion.for3Use2_13)
+      "com.decodified" %% "scala-ssh" % "0.11.1" % "provided"
     )
   )
 
-lazy val iam = awsProject("iam").settings(crossScalaVersions += scala3)
+lazy val iam = awsProject("iam")
 lazy val dynamodb = awsProject("dynamodb").settings(dynamoTestSettings)
-lazy val emr = awsProject("emr").settings(crossScalaVersions += scala3).dependsOn(ec2 % "test")
-lazy val redshift = awsProject("redshift").settings(crossScalaVersions += scala3)
-lazy val s3 = awsProject("s3").settings(crossScalaVersions += scala3)
-lazy val simpledb = awsProject("simpledb").settings(crossScalaVersions += scala3)
-lazy val sqs = awsProject("sqs").settings(crossScalaVersions += scala3)
-lazy val sts = awsProject("sts").settings(crossScalaVersions += scala3)
-lazy val stepfunctions = awsProject("stepfunctions").settings(crossScalaVersions += scala3).dependsOn(iam % "test")
+lazy val emr = awsProject("emr").dependsOn(ec2 % "test")
+lazy val redshift = awsProject("redshift")
+lazy val s3 = awsProject("s3")
+lazy val simpledb = awsProject("simpledb")
+lazy val sqs = awsProject("sqs")
+lazy val sts = awsProject("sts")
+lazy val stepfunctions = awsProject("stepfunctions").dependsOn(iam % "test")
 
 def awsProject(service: String) = {
   Project
@@ -110,7 +109,7 @@ def awsProject(service: String) = {
       libraryDependencies ++= Seq(
         "com.amazonaws" % s"aws-java-sdk-$service" % awsJavaSdkVersion,
         "ch.qos.logback" % "logback-classic" % "1.2.3" % "test",
-        "org.scalatest" %% "scalatest" % "3.2.8" % "test"
+        "org.scalatest" %% "scalatest" % "3.2.9" % "test"
       )
     )
     .dependsOn(core)

--- a/dynamodb/src/main/scala-2/awscala/dynamodbv2/TableCompat.scala
+++ b/dynamodb/src/main/scala-2/awscala/dynamodbv2/TableCompat.scala
@@ -1,0 +1,61 @@
+package awscala.dynamodbv2
+
+import DynamoDB.SimplePk
+
+import scala.reflect.runtime.{ universe => u }
+import scala.reflect.runtime.universe.termNames
+
+import scala.collection.mutable.ListBuffer
+import scala.annotation.StaticAnnotation
+
+class hashPK extends StaticAnnotation
+class rangePK extends StaticAnnotation
+
+private[dynamodbv2] trait TableCompat { self: Table =>
+
+  def putItem[T: u.TypeTag](entity: T)(implicit dynamoDB: DynamoDB): Unit = {
+    val constructorArgs: Seq[AnnotatedConstructorArgMeta] = extractAnnotatedConstructorArgs(entity)
+    val getterCallResults: Seq[(String, AnyRef)] = extractGetterNameAndValue(entity)
+
+    var maybeHashPK: Option[Any] = None
+    var maybeRangePK: Option[Any] = None
+    val attributes: ListBuffer[(String, AnyRef)] = ListBuffer()
+    for (nameAndValue <- getterCallResults) {
+      val (name, value) = nameAndValue
+      constructorArgs.find { arg => name == arg.name } match {
+        case Some(arg) if arg.annotationNames.exists(_.contains("hashPK")) => maybeHashPK = Some(value)
+        case Some(arg) if arg.annotationNames.exists(_.contains("rangePK")) => maybeRangePK = Some(value)
+        case _ => attributes += nameAndValue
+      }
+    }
+    (maybeHashPK, maybeRangePK) match {
+      case (Some(hashPK), Some(rangePK)) =>
+        dynamoDB.put(this, hashPK, rangePK, attributes.toSeq: _*)
+      case (Some(hashPK), None) =>
+        dynamoDB.put(this, hashPK, attributes.toSeq: _*)
+      case _ =>
+        throw new Exception(s"Primary key is not defined for ${entity.getClass.getName} (constructor args are $constructorArgs)")
+    }
+  }
+
+  def putItem(hashPK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = {
+    dynamoDB.put(this, hashPK, attributes: _*)
+  }
+  def putItem(hashPK: Any, rangePK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = {
+    dynamoDB.put(this, hashPK, rangePK, attributes: _*)
+  }
+
+  private case class AnnotatedConstructorArgMeta(name: String, annotationNames: Seq[String])
+
+  private def extractAnnotatedConstructorArgs[T: u.TypeTag](entity: T): Seq[AnnotatedConstructorArgMeta] = {
+    u.typeOf[entity.type].decl(termNames.CONSTRUCTOR).asMethod.paramLists.flatten
+      .collect({
+        case t if t != null && t.annotations.nonEmpty =>
+          Some(AnnotatedConstructorArgMeta(
+            name = t.name.toString,
+            // FIXME: should we use canonical name?
+            annotationNames = t.annotations.map(_.toString)))
+        case _ => None
+      }).flatten
+  }
+}

--- a/dynamodb/src/main/scala-3/awscala/dynamodbv2/TableCompat.scala
+++ b/dynamodb/src/main/scala-3/awscala/dynamodbv2/TableCompat.scala
@@ -1,0 +1,12 @@
+package awscala.dynamodbv2
+
+import DynamoDB.SimplePk
+
+private[dynamodbv2] trait TableCompat { self: Table =>
+  def putItem(hashPK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = {
+    dynamoDB.put(this, hashPK, attributes: _*)
+  }
+  def putItem(hashPK: Any, rangePK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = {
+    dynamoDB.put(this, hashPK, rangePK, attributes: _*)
+  }
+}

--- a/dynamodb/src/main/scala/awscala/dynamodbv2/ResultPager.scala
+++ b/dynamodb/src/main/scala/awscala/dynamodbv2/ResultPager.scala
@@ -82,9 +82,10 @@ sealed trait ResultPager[TReq, TRes] extends Iterator[Item] {
     } else if (lastKey == null) {
       false
     } else {
-      do {
+      while ({
         nextPage(withExclusiveStartKey(request, lastKey))
-      } while (lastKey != null && items.isEmpty) // there are potentially more matching data, but this page didn't contain any
+        lastKey != null && items.isEmpty // there are potentially more matching data, but this page didn't contain any
+      }) {}
       items.nonEmpty
     }
   }

--- a/dynamodb/src/main/scala/awscala/dynamodbv2/Table.scala
+++ b/dynamodb/src/main/scala/awscala/dynamodbv2/Table.scala
@@ -81,12 +81,12 @@ case class Table(
     var maybeHashPK: Option[Any] = None
     var maybeRangePK: Option[Any] = None
     val attributes: ListBuffer[(String, AnyRef)] = ListBuffer()
-    for (arg <- constructorArgs) {
-      getterCallResults.find { case (name, _) => name == arg.name } match {
-        case Some((_, value)) if arg.annotationNames.contains("hashPK") => maybeHashPK = Some(value)
-        case Some((_, value)) if arg.annotationNames.contains("rangePK") => maybeRangePK = Some(value)
-        case Some(nameAndValue) => attributes += nameAndValue
-        case _ => // noop
+    for (nameAndValue <- getterCallResults) {
+      val (name, value) = nameAndValue
+      constructorArgs.find { arg => name == arg.name } match {
+        case Some(arg) if arg.annotationNames.exists(_.contains("hashPK")) => maybeHashPK = Some(value)
+        case Some(arg) if arg.annotationNames.exists(_.contains("rangePK")) => maybeRangePK = Some(value)
+        case _ => attributes += nameAndValue
       }
     }
     (maybeHashPK, maybeRangePK) match {

--- a/dynamodb/src/main/scala/awscala/dynamodbv2/Table.scala
+++ b/dynamodb/src/main/scala/awscala/dynamodbv2/Table.scala
@@ -5,10 +5,7 @@ import DynamoDB.{ CompositePk, SimplePk }
 import java.lang.reflect.Modifier
 import com.amazonaws.services.{ dynamodbv2 => aws }
 
-import scala.annotation.StaticAnnotation
 import scala.collection.mutable.ListBuffer
-import scala.reflect.runtime.{ universe => u }
-import scala.reflect.runtime.universe.termNames
 
 object Table {
 
@@ -25,9 +22,6 @@ object Table {
       globalSecondaryIndexes, provisionedThroughput, Option(billingMode))
 }
 
-class hashPK extends StaticAnnotation
-class rangePK extends StaticAnnotation
-
 case class Table(
   name: String,
   hashPK: String,
@@ -36,7 +30,7 @@ case class Table(
   localSecondaryIndexes: Seq[LocalSecondaryIndex] = Nil,
   globalSecondaryIndexes: Seq[GlobalSecondaryIndex] = Nil,
   provisionedThroughput: Option[ProvisionedThroughput] = None,
-  billingMode: Option[aws.model.BillingMode] = None) {
+  billingMode: Option[aws.model.BillingMode] = None) extends TableCompat {
 
   // ------------------------------------------
   // Items
@@ -74,46 +68,7 @@ case class Table(
     dynamoDB.put(this, hashPK, rangePK, attrs: _*)
   }
 
-  def putItem[T: u.TypeTag](entity: T)(implicit dynamoDB: DynamoDB): Unit = {
-    val constructorArgs: Seq[AnnotatedConstructorArgMeta] = extractAnnotatedConstructorArgs(entity)
-    val getterCallResults: Seq[(String, AnyRef)] = extractGetterNameAndValue(entity)
-
-    var maybeHashPK: Option[Any] = None
-    var maybeRangePK: Option[Any] = None
-    val attributes: ListBuffer[(String, AnyRef)] = ListBuffer()
-    for (nameAndValue <- getterCallResults) {
-      val (name, value) = nameAndValue
-      constructorArgs.find { arg => name == arg.name } match {
-        case Some(arg) if arg.annotationNames.exists(_.contains("hashPK")) => maybeHashPK = Some(value)
-        case Some(arg) if arg.annotationNames.exists(_.contains("rangePK")) => maybeRangePK = Some(value)
-        case _ => attributes += nameAndValue
-      }
-    }
-    (maybeHashPK, maybeRangePK) match {
-      case (Some(hashPK), Some(rangePK)) =>
-        dynamoDB.put(this, hashPK, rangePK, attributes.toSeq: _*)
-      case (Some(hashPK), None) =>
-        dynamoDB.put(this, hashPK, attributes.toSeq: _*)
-      case _ =>
-        throw new Exception(s"Primary key is not defined for ${entity.getClass.getName}")
-    }
-  }
-
-  private case class AnnotatedConstructorArgMeta(name: String, annotationNames: Seq[String])
-
-  private def extractAnnotatedConstructorArgs[T: u.TypeTag](entity: T): Seq[AnnotatedConstructorArgMeta] = {
-    u.typeOf[entity.type].decl(termNames.CONSTRUCTOR).asMethod.paramLists.flatten
-      .collect({
-        case t if t != null && t.annotations.nonEmpty =>
-          Some(AnnotatedConstructorArgMeta(
-            name = t.name.toString,
-            // FIXME: should we use canonical name?
-            annotationNames = t.annotations.map(_.toString)))
-        case _ => None
-      }).flatten
-  }
-
-  private def extractGetterNameAndValue(obj: Any): Seq[(String, AnyRef)] = {
+  protected def extractGetterNameAndValue(obj: Any): Seq[(String, AnyRef)] = {
     val clazz = obj.getClass
     val privateInstanceFieldNames: Seq[String] = clazz.getDeclaredFields
       .filter(f =>
@@ -132,14 +87,6 @@ case class Table(
 
     getterMethodNames.map(name => (name, clazz.getDeclaredMethod(name).invoke(obj)))
   }
-
-  def putItem(hashPK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = {
-    dynamoDB.put(this, hashPK, attributes: _*)
-  }
-  def putItem(hashPK: Any, rangePK: Any, attributes: SimplePk*)(implicit dynamoDB: DynamoDB): Unit = {
-    dynamoDB.put(this, hashPK, rangePK, attributes: _*)
-  }
-
   def delete(hashPK: Any)(implicit dynamoDB: DynamoDB): Unit = deleteItem(hashPK)
   def delete(hashPK: Any, rangePK: Any)(implicit dynamoDB: DynamoDB): Unit = deleteItem(hashPK, rangePK)
 

--- a/dynamodb/src/test/scala-2/awscala/DynamoDBV2AnnotationsSpec.scala
+++ b/dynamodb/src/test/scala-2/awscala/DynamoDBV2AnnotationsSpec.scala
@@ -1,0 +1,62 @@
+package awscala
+
+import java.util.Date
+
+import awscala.dynamodbv2._
+import com.amazonaws.services.dynamodbv2.model.{ ProvisionedThroughputDescription, TableDescription, TableStatus }
+import com.amazonaws.services.dynamodbv2.util.TableUtils
+import com.amazonaws.services.{ dynamodbv2 => aws }
+import org.scalatest._
+import org.slf4j._
+
+import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+class DynamoDBV2AnnotationsSpec extends AnyFlatSpec with Matchers {
+
+  behavior of "DynamoDB"
+
+  val log: Logger = LoggerFactory.getLogger(this.getClass)
+
+  case class TestMember(
+    @hashPK val id: Int,
+    @rangePK val Country: String,
+    val Company: String,
+    val Name: String,
+    val Age: Int)
+  it should "allows using case class with annotation in put method" in {
+    implicit val dynamoDB: DynamoDB = DynamoDB.local()
+    val tableName = s"Members_${System.currentTimeMillis}"
+    val createdTableMeta: TableMeta = dynamoDB.createTable(
+      name = tableName,
+      hashPK = "Id" -> AttributeType.Number,
+      rangePK = "Country" -> AttributeType.String,
+      otherAttributes = Seq(
+        "Company" -> AttributeType.String),
+      indexes = Seq(
+        LocalSecondaryIndex(
+          name = "CompanyIndex",
+          keySchema = Seq(KeySchema("Id", KeyType.Hash), KeySchema("Company", KeyType.Range)),
+          projection = Projection(ProjectionType.Include, Seq("Company")))))
+    log.info(s"Created Table: $createdTableMeta")
+
+    println(s"Waiting for DynamoDB table activation...")
+    TableUtils.waitUntilActive(dynamoDB, createdTableMeta.name)
+    println("")
+    println(s"Created DynamoDB table has been activated.")
+
+    val members: Table = dynamoDB.table(tableName).get
+    val member = TestMember(1, "PL", "DataMass", "Alex", 29)
+    println(members)
+    members.putItem(member)
+
+    println(members)
+    println(members.get(1, "PL"))
+    println(members.get(1, "PL").get.attributes.find(_.name == "Name").get.value)
+
+    members.get(1, "PL").get.attributes.find(_.name == "Name").get.value.s.get should equal("Alex")
+    members.get(1, "PL").get.attributes.find(_.name == "Company").get.value.s.get should equal("DataMass")
+    members.get(1, "PL").get.attributes.find(_.name == "Country").get.value.s.get should equal("PL")
+    members.destroy()
+  }
+}

--- a/dynamodb/src/test/scala/awscala/DynamoDBV2Spec.scala
+++ b/dynamodb/src/test/scala/awscala/DynamoDBV2Spec.scala
@@ -103,44 +103,6 @@ class DynamoDBV2Spec extends AnyFlatSpec with Matchers {
     members.destroy()
   }
 
-  case class TestMember(
-    @hashPK id: Int,
-    @rangePK Country: String,
-    Company: String,
-    Name: String,
-    Age: Int)
-  it should "allows using case class with annotation in put method" in {
-    implicit val dynamoDB: DynamoDB = DynamoDB.local()
-    val tableName = s"Members_${System.currentTimeMillis}"
-    val createdTableMeta: TableMeta = dynamoDB.createTable(
-      name = tableName,
-      hashPK = "Id" -> AttributeType.Number,
-      rangePK = "Country" -> AttributeType.String,
-      otherAttributes = Seq(
-        "Company" -> AttributeType.String),
-      indexes = Seq(
-        LocalSecondaryIndex(
-          name = "CompanyIndex",
-          keySchema = Seq(KeySchema("Id", KeyType.Hash), KeySchema("Company", KeyType.Range)),
-          projection = Projection(ProjectionType.Include, Seq("Company")))))
-    log.info(s"Created Table: $createdTableMeta")
-
-    println(s"Waiting for DynamoDB table activation...")
-    TableUtils.waitUntilActive(dynamoDB, createdTableMeta.name)
-    println("")
-    println(s"Created DynamoDB table has been activated.")
-
-    val members: Table = dynamoDB.table(tableName).get
-    val member = TestMember(1, "PL", "DataMass", "Alex", 29)
-
-    members.putItem(member)
-
-    members.get(1, "PL").get.attributes.find(_.name == "Name").get.value.s.get should equal("Alex")
-    members.get(1, "PL").get.attributes.find(_.name == "Company").get.value.s.get should equal("DataMass")
-    members.get(1, "PL").get.attributes.find(_.name == "Country").get.value.s.get should equal("PL")
-    members.destroy()
-  }
-
   it should "provide cool APIs for Hash/Range PK tables" in {
     implicit val dynamoDB: DynamoDB = DynamoDB.local()
 


### PR DESCRIPTION
Adds Scala 3 support to all modules, with case class field annotations restricted to Scala 2 only. (I missed out the `core` and `ec2` modules in #251 🤦‍♂️ - adding Scala 3 to `core` produced some weird errors in `dynamodb`, so it seemed easiest to cross-build that too.)

Depends on #262 