### PR TITLE
Add created date for IAM Access Keys

### DIFF
--- a/iam/src/main/scala/awscala/iam/AccessKey.scala
+++ b/iam/src/main/scala/awscala/iam/AccessKey.scala
@@ -1,6 +1,7 @@
 package awscala.iam
 
 import com.amazonaws.services.{ identitymanagement => aws }
+import java.util.Date
 
 object AccessKey {
 
@@ -8,19 +9,22 @@ object AccessKey {
     userName = ak.getUserName,
     accessKeyId = ak.getAccessKeyId,
     secretAccessKey = Option(ak.getSecretAccessKey),
-    status = ak.getStatus)
+    status = ak.getStatus,
+    createDate = ak.getCreateDate
+  )
   def apply(m: aws.model.AccessKeyMetadata): AccessKey = new AccessKey(
     userName = m.getUserName,
     accessKeyId = m.getAccessKeyId,
     secretAccessKey = None,
-    status = m.getStatus)
+    status = m.getStatus,
+    createDate = m.getCreateDate
+  )
 }
 
-case class AccessKey(userName: String, accessKeyId: String, secretAccessKey: Option[String], status: String)
+case class AccessKey(userName: String, accessKeyId: String, secretAccessKey: Option[String], status: String, createDate: Date)
   extends aws.model.AccessKey(userName, accessKeyId, status, secretAccessKey.orNull[String]) {
 
   def activate()(implicit iam: IAM) = iam.activateAccessKey(this)
   def inactivate()(implicit iam: IAM) = iam.inactivateAccessKey(this)
   def destroy()(implicit iam: IAM) = iam.delete(this)
 }
-

--- a/iam/src/test/scala/awscala/IAMSpec.scala
+++ b/iam/src/test/scala/awscala/IAMSpec.scala
@@ -1,7 +1,8 @@
 package awscala
 
-import awscala.iam._
+import java.util.Date
 
+import awscala.iam._
 import org.slf4j._
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -40,6 +41,15 @@ class IAMSpec extends AnyFlatSpec with Matchers {
     group.destroy()
 
     user.destroy()
+  }
+
+  it should "return correct dates for access keys" in {
+    implicit val iam = IAM()
+    val userName = s"awscala-unit-test-user-${System.currentTimeMillis}"
+    val user: User = iam.createUser(userName)
+    val userAccessKey = user.createAccessKey()
+    val accessKeyCreatedDate = userAccessKey.createDate
+    accessKeyCreatedDate.getTime should equal(new Date().getTime +- 1000)
   }
 
 }


### PR DESCRIPTION
Hi!

This is a request to add the date created field for an access key. In the Java SDK that data comes from `.getCreateDate()`, and this PR is an attempt to add that information to this project. At the moment calling that function for an access key in this project will return `null`.

I don't have much experience with creating pull requests, so please let me know if I should change something and I will try my best :)

I added a simple test to see if the access key create date is approximately the same as when the test is being run. Best I could think of in this situation.